### PR TITLE
Use new layer parameter options from glazed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: gifs
 
-VERSION=v0.1.7
+VERSION=v0.1.8
 
 TAPES=$(shell ls doc/vhs/*tape)
 gifs: $(TAPES)

--- a/cmd/sqleton/cmds/queries.go
+++ b/cmd/sqleton/cmds/queries.go
@@ -65,15 +65,15 @@ func NewQueriesCommand(
 	aliases []*glazed_cmds.CommandAlias,
 	options ...glazed_cmds.CommandDescriptionOption,
 ) (*QueriesCommand, error) {
-	glazeParameterLayer, err := cli.NewGlazedParameterLayers()
-	if err != nil {
-		return nil, err
-	}
-
-	defaults := &cli.FieldsFilterFlagsDefaults{
-		Fields: []string{"name", "short", "source"},
-	}
-	err = glazeParameterLayer.FieldsFiltersParameterLayer.InitializeParameterDefaultsFromStruct(defaults)
+	glazeParameterLayer, err := cli.NewGlazedParameterLayers(
+		cli.WithFieldsFiltersParameterLayerOptions(
+			layers.WithDefaults(
+				&cli.FieldsFilterFlagsDefaults{
+					Fields: []string{"name", "short", "source"},
+				},
+			),
+		),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/go-go-golems/clay v0.0.6
-	github.com/go-go-golems/glazed v0.2.18
+	github.com/go-go-golems/glazed v0.2.19
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/huandu/go-sqlbuilder v1.18.0
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-go-golems/clay v0.0.6 h1:wMOByY3io8Pk8P/K4L4RkFvefT3eMOo9ndTF+Dr07X0=
 github.com/go-go-golems/clay v0.0.6/go.mod h1:5xTh9jOtcCzPPbMY9ZBEn4pd/VmXjv9W7+MKqmjog6s=
-github.com/go-go-golems/glazed v0.2.18 h1:vE3yT5tohYZGQ5txWPZXkoQlc1/tyWXHQbkZYrLhwew=
-github.com/go-go-golems/glazed v0.2.18/go.mod h1:Nf4vx3TF7hrt66F1TALSOcvIvPBnq38LjKUy5HyBS6g=
+github.com/go-go-golems/glazed v0.2.19 h1:p+ephsK0AJPjofhv5F1aj84edoNQtQNzW175/Wq3BWE=
+github.com/go-go-golems/glazed v0.2.19/go.mod h1:Nf4vx3TF7hrt66F1TALSOcvIvPBnq38LjKUy5HyBS6g=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=

--- a/pkg/settings.go
+++ b/pkg/settings.go
@@ -29,20 +29,9 @@ func NewSqlConnectionParameterLayer(options ...layers.ParameterLayerOptions) (*C
 
 func (cp *ConnectionParameterLayer) ParseFlagsFromCobraCommand(cmd *cobra.Command) (map[string]interface{}, error) {
 	// actually hijack and load everything from viper instead of cobra...
-	ps := make(map[string]interface{})
-
-	for _, f := range cp.Flags {
-		flagName := cp.Prefix + f.Name
-		switch f.Type {
-		case parameters.ParameterTypeString:
-			v := viper.GetString(flagName)
-			ps[f.Name] = v
-		case parameters.ParameterTypeInteger:
-			v := viper.GetInt(flagName)
-			ps[f.Name] = v
-		default:
-			return nil, errors.Errorf("Unknown DB Connection parameter type %s for flag: %s", f.Type, f.Name)
-		}
+	ps, err := parameters.GatherFlagsFromViper(cp.Flags, false, cp.Prefix)
+	if err != nil {
+		return nil, err
 	}
 
 	// now load from flag overrides


### PR DESCRIPTION
- :arrow_up: Bump sqleton
- Empty tag to retrigger release
- :art: Simplify parsing of SQL viper strings
- :art: :pencil: Minor refactor to use the new layer options from glazed
