### PR TITLE
:sparkles: Add support for subqueries

### DIFF
--- a/cmd/sqleton/doc/topics/03-subqueries.md
+++ b/cmd/sqleton/doc/topics/03-subqueries.md
@@ -1,0 +1,90 @@
+---
+Title: Use subqueries in your SQL
+Slug: subqueries
+Short: |
+  ```
+  You can add subQueries as a field in your YAML sqleton command. They can then be used
+  withing your templates to evaluate nested values.
+  ```
+Topics:
+- queries
+IsTemplate: false
+IsTopLevel: false
+ShowPerDefault: false
+SectionType: GeneralTopic
+---
+If you need to use subqueries in your SQL, you can add them as a field in your YAML sqleton command.
+
+They can then be used withing your templates to evaluate nested values.
+
+This makes it easy to create pivoted tables, for example.
+
+```yaml
+name: posts-counts
+short: Count posts by type
+flags:
+  - name: post_type
+    description: Post type
+    type: stringList
+    required: false
+subqueries:
+  post_types: |
+    SELECT DISTINCT post_type 
+    FROM wp_posts
+    GROUP BY post_type
+    LIMIT 4
+query: |
+  {{ $types := sqlColumn (subQuery "post_types") }}
+  SELECT
+  {{ range $i, $v := $types }}
+    {{ $v2 := printf "count%d" $i }}
+    (
+      SELECT count(*) AS count
+      FROM wp_posts
+      WHERE post_status = 'publish'
+      AND post_type = '{{ $v }}'
+    ) AS `{{ $v }}` {{ if not (eq $i (sub (len $types) 1)) }}, {{ end }}
+  {{ end }}
+```
+
+If you print out the query before running it:
+
+```
+❯ sqleton wp posts-counts --print-query      
+SELECT
+   (
+    SELECT count(*) AS count
+    FROM wp_posts
+    WHERE post_status = 'publish'
+    AND post_type = 'attachment'
+  ) AS `attachment` , 
+  (
+    SELECT count(*) AS count
+    FROM wp_posts
+    WHERE post_status = 'publish'
+    AND post_type = 'custom_css'
+  ) AS `custom_css` , 
+  (
+    SELECT count(*) AS count
+    FROM wp_posts
+    WHERE post_status = 'publish'
+    AND post_type = 'export_template'
+  ) AS `export_template` , 
+  (
+    SELECT count(*) AS count
+    FROM wp_posts
+    WHERE post_status = 'publish'
+    AND post_type = 'faq'
+  ) AS `faq` 
+```
+
+And then run it:
+
+```
+❯ sqleton wp posts-counts              
++------------+------------+-----------------+-----+
+| attachment | custom_css | export_template | faq |
++------------+------------+-----------------+-----+
+| 0          | 1          | 2               | 35  |
++------------+------------+-----------------+-----+
+```

--- a/cmd/sqleton/queries/wp/posts-counts.yaml
+++ b/cmd/sqleton/queries/wp/posts-counts.yaml
@@ -1,0 +1,25 @@
+name: posts-counts
+short: Count posts by type
+flags:
+  - name: post_type
+    description: Post type
+    type: stringList
+    required: false
+subqueries:
+  post_types: |
+    SELECT post_type
+    FROM wp_posts
+    GROUP BY post_type
+    LIMIT 4
+query: |
+  {{ $types := sqlColumn (subQuery "post_types") }}
+  SELECT
+  {{ range $i, $v := $types }}
+    {{ $v2 := printf "count%d" $i }}
+     (
+      SELECT count(*) AS count
+      FROM wp_posts
+      WHERE post_status = 'publish'
+      AND post_type = '{{ $v }}'
+    ) AS `{{ $v }}` {{ if not (eq $i (sub (len $types) 1)) }}, {{ end }}
+  {{ end }}

--- a/pkg/sql.go
+++ b/pkg/sql.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
@@ -46,6 +47,7 @@ type DBConnectionFactory func(parsedLayers map[string]*layers.ParsedParameterLay
 type SqlCommand struct {
 	description         *cmds.CommandDescription
 	Query               string
+	SubQueries          map[string]string
 	dbConnectionFactory DBConnectionFactory
 }
 
@@ -64,6 +66,12 @@ func WithDbConnectionFactory(factory DBConnectionFactory) SqlCommandOption {
 func WithQuery(query string) SqlCommandOption {
 	return func(s *SqlCommand) {
 		s.Query = query
+	}
+}
+
+func WithSubQueries(subQueries map[string]string) SqlCommandOption {
+	return func(s *SqlCommand) {
+		s.SubQueries = subQueries
 	}
 }
 
@@ -96,6 +104,7 @@ func NewSqlCommand(
 
 	ret := &SqlCommand{
 		description: description,
+		SubQueries:  make(map[string]string),
 	}
 
 	for _, option := range options {
@@ -128,7 +137,7 @@ func (s *SqlCommand) Run(
 
 	printQuery, _ := ps["print-query"].(bool)
 	if printQuery {
-		query, err := s.RenderQuery(ps)
+		query, err := s.RenderQuery(ctx, ps, db)
 		if err != nil {
 			return errors.Wrapf(err, "Could not generate query")
 		}
@@ -176,9 +185,13 @@ func sqlIn(values []interface{}) string {
 	return strings.Join(strValues, ",")
 }
 
-func sqlIntIn(values []int) string {
-	strValues := make([]string, len(values))
-	for i, v := range values {
+func sqlIntIn(values interface{}) string {
+	v_, ok := cast.CastInterfaceToIntList[int64](values)
+	if !ok {
+		return ""
+	}
+	strValues := make([]string, len(v_))
+	for i, v := range v_ {
 		strValues[i] = fmt.Sprintf("%d", v)
 	}
 	return strings.Join(strValues, ",")
@@ -196,23 +209,10 @@ func sqlLike(value string) string {
 	return "'%" + value + "%'"
 }
 
-func stripNewline(value string) string {
-	return strings.Replace(value, "\n", " ", -1)
-}
-
-func padLeft(value string, length int) string {
-	return fmt.Sprintf("%*s", -length, value)
-}
-
-func padRight(value string, length int) string {
-	return fmt.Sprintf("%-*s", length, value)
-}
-
-func (s *SqlCommand) RenderQuery(ps map[string]interface{}) (string, error) {
-
+func createTemplate(ctx context.Context, name string, ps map[string]interface{}, db *sqlx.DB) *template.Template {
 	t2 := templating.CreateTemplate("query").
+		Funcs(templating.TemplateFuncs).
 		Funcs(template.FuncMap{
-			"join":          strings.Join,
 			"sqlStringIn":   sqlStringIn,
 			"sqlStringLike": sqlStringLike,
 			"sqlIntIn":      sqlIntIn,
@@ -222,10 +222,160 @@ func (s *SqlCommand) RenderQuery(ps map[string]interface{}) (string, error) {
 			"sqlLike":       sqlLike,
 			"sqlString":     sqlString,
 			"sqlEscape":     sqlEscape,
-			"stripNewline":  stripNewline,
-			"padLeft":       padLeft,
-			"padRight":      padRight,
+			"sqlSlice": func(query string, args ...interface{}) (interface{}, error) {
+				_, rows, err := runQuery(ctx, query, args, ps, db)
+				if err != nil {
+					return nil, errors.Errorf("Could not run query: %s", query)
+				}
+				defer rows.Close()
+
+				if rows.Next() {
+					ret, err := rows.SliceScan()
+					if err != nil {
+						return nil, errors.Errorf("Could not scan query: %s", query)
+					}
+
+					return ret, nil
+				}
+
+				return nil, nil
+			},
+			"sqlColumn": func(query string, args ...interface{}) ([]interface{}, error) {
+				renderedQuery, rows, err := runQuery(ctx, query, args, ps, db)
+				if err != nil {
+					return nil, errors.Errorf("Could not run query: %s", renderedQuery)
+				}
+				defer rows.Close()
+
+				ret := make([]interface{}, 0)
+				for rows.Next() {
+					rows_, err := rows.SliceScan()
+					if err != nil {
+						return nil, errors.Errorf("Could not scan query: %s", renderedQuery)
+					}
+
+					if len(rows_) != 1 {
+						return nil, errors.Errorf("Expected 1 column, got %d", len(rows_))
+					}
+					ret = append(ret, rows_[0])
+
+				}
+
+				return ret, nil
+			},
+			"sqlSingle": func(query string, args ...interface{}) (interface{}, error) {
+				renderedQuery, rows, err := runQuery(ctx, query, args, ps, db)
+				if err != nil {
+					return nil, errors.Errorf("Could not run query: %s", renderedQuery)
+				}
+				defer rows.Close()
+
+				ret := make([]interface{}, 0)
+				if rows.Next() {
+					rows_, err := rows.SliceScan()
+					if err != nil {
+						return nil, errors.Errorf("Could not scan query: %s", renderedQuery)
+					}
+
+					if len(rows_) != 1 {
+						return nil, errors.Errorf("Expected 1 column, got %d", len(rows_))
+					}
+
+					ret = append(ret, rows_[0])
+				}
+
+				if rows.Next() {
+					return nil, errors.Errorf("Expected 1 row, got more")
+				}
+
+				if len(ret) == 0 {
+					return nil, nil
+				}
+
+				if len(ret) > 1 {
+					return nil, errors.Errorf("Expected 1 row, got %d", len(ret))
+				}
+
+				return ret[0], nil
+			},
+			"sqlMap": func(query string, args ...interface{}) (interface{}, error) {
+				renderedQuery, rows, err := runQuery(ctx, query, args, ps, db)
+				if err != nil {
+					return nil, errors.Errorf("Could not run query: %s", renderedQuery)
+				}
+				defer rows.Close()
+
+				ret := []map[string]interface{}{}
+
+				for rows.Next() {
+					ret_ := make(map[string]interface{})
+					err = rows.MapScan(ret_)
+					if err != nil {
+						return nil, errors.Errorf("Could not scan query: %s", renderedQuery)
+					}
+
+					ret = append(ret, ret_)
+				}
+
+				return ret, nil
+			},
 		})
+
+	return t2
+}
+
+func runQuery(ctx context.Context, query string, args []interface{}, ps map[string]interface{}, db *sqlx.DB) (string, *sqlx.Rows, error) {
+	if db == nil {
+		return "", nil, errors.New("No database connection")
+	}
+
+	ps2 := map[string]interface{}{}
+	for k, v := range ps {
+		ps2[k] = v
+	}
+	// args is k, v, k, v, k, v
+	if len(args)%2 != 0 {
+		return "", nil, errors.Errorf("Could not run query: %s", query)
+	}
+	for i := 0; i < len(args); i += 2 {
+		k, ok := args[i].(string)
+		if !ok {
+			return "", nil, errors.Errorf("Could not run query: %s", query)
+		}
+		ps2[k] = args[i+1]
+	}
+
+	t2 := createTemplate(ctx, "sql", ps2, db)
+	t, err := t2.Parse(query)
+	if err != nil {
+		return "", nil, err
+	}
+
+	query_, err := templating.RenderTemplate(t, ps2)
+	if err != nil {
+		return query_, nil, err
+	}
+
+	stmt, err := db.PreparexContext(ctx, query_)
+	if err != nil {
+		return query_, nil, err
+	}
+
+	rows, err := stmt.QueryxContext(ctx)
+	if err != nil {
+		return query_, nil, err
+	}
+
+	return query_, rows, err
+}
+
+func (s *SqlCommand) RenderQuery(
+	ctx context.Context,
+	ps map[string]interface{},
+	db *sqlx.DB,
+) (string, error) {
+	t2 := createTemplate(ctx, "query", ps, db)
+
 	t, err := t2.Parse(s.Query)
 	if err != nil {
 		return "", errors.Wrap(err, "Could not parse query template")
@@ -314,7 +464,7 @@ func (s *SqlCommand) RunQueryIntoGlaze(
 	ps map[string]interface{},
 	gp cmds.Processor) error {
 
-	query, err := s.RenderQuery(ps)
+	query, err := s.RenderQuery(ctx, ps, db)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql.go
+++ b/pkg/sql.go
@@ -222,23 +222,25 @@ func createTemplate(ctx context.Context, name string, ps map[string]interface{},
 			"sqlLike":       sqlLike,
 			"sqlString":     sqlString,
 			"sqlEscape":     sqlEscape,
-			"sqlSlice": func(query string, args ...interface{}) (interface{}, error) {
+			"sqlSlice": func(query string, args ...interface{}) ([]interface{}, error) {
 				_, rows, err := runQuery(ctx, query, args, ps, db)
 				if err != nil {
 					return nil, errors.Errorf("Could not run query: %s", query)
 				}
 				defer rows.Close()
 
-				if rows.Next() {
-					ret, err := rows.SliceScan()
+				ret := []interface{}{}
+
+				for rows.Next() {
+					ret_, err := rows.SliceScan()
 					if err != nil {
 						return nil, errors.Errorf("Could not scan query: %s", query)
 					}
 
-					return ret, nil
+					ret = append(ret, ret_)
 				}
 
-				return nil, nil
+				return ret, nil
 			},
 			"sqlColumn": func(query string, args ...interface{}) ([]interface{}, error) {
 				renderedQuery, rows, err := runQuery(ctx, query, args, ps, db)


### PR DESCRIPTION
Closes #129

- :sparkles: Add interpreting sub values
- :ambulance: Add tests for slice and map
- :sparkles: Add subquery command
- :sparkles: Add documentation for subqueries
