### PR TITLE
Add print env/settings commands

### DIFF
--- a/cmd/sqleton/cmds/db.go
+++ b/cmd/sqleton/cmds/db.go
@@ -174,7 +174,11 @@ var dbPrintEnvCmd = &cobra.Command{
 		fmt.Printf("%s%s=%s\n", prefix, "USER", source.Username)
 		fmt.Printf("%s%s=%s\n", prefix, "PASSWORD", source.Password)
 		fmt.Printf("%s%s=%s\n", prefix, "SCHEMA", source.Schema)
-		fmt.Printf("%s%s=%s\n", prefix, "USE_DBT_PROFILES", config.UseDbtProfiles)
+		if config.UseDbtProfiles {
+			fmt.Printf("%s%s=1\n", prefix, "USE_DBT_PROFILES")
+		} else {
+			fmt.Printf("%s%s=\n", prefix, "USE_DBT_PROFILES")
+		}
 		fmt.Printf("%s%s=%s\n", prefix, "DBT_PROFILES_PATH", config.DbtProfilesPath)
 		fmt.Printf("%s%s=%s\n", prefix, "DBT_PROFILE", config.DbtProfile)
 	},
@@ -223,16 +227,16 @@ var dbPrintSettingsCmd = &cobra.Command{
 			useDbtProfiles = "SQLETON_USE_DBT_PROFILES"
 			dbtProfilesPath = "SQLETON_DBT_PROFILES_PATH"
 		} else if withEnvPrefix != "" {
-			host = fmt.Sprintf("%s_HOST", withEnvPrefix)
-			port = fmt.Sprintf("%s_PORT", withEnvPrefix)
-			database = fmt.Sprintf("%s_DATABASE", withEnvPrefix)
-			user = fmt.Sprintf("%s_USER", withEnvPrefix)
-			password = fmt.Sprintf("%s_PASSWORD", withEnvPrefix)
-			type_ = fmt.Sprintf("%s_TYPE", withEnvPrefix)
-			schema = fmt.Sprintf("%s_SCHEMA", withEnvPrefix)
-			dbtProfile = fmt.Sprintf("%s_DBT_PROFILE", withEnvPrefix)
-			useDbtProfiles = fmt.Sprintf("%s_USE_DBT_PROFILES", withEnvPrefix)
-			dbtProfilesPath = fmt.Sprintf("%s_DBT_PROFILES_PATH", withEnvPrefix)
+			host = fmt.Sprintf("%sHOST", withEnvPrefix)
+			port = fmt.Sprintf("%sPORT", withEnvPrefix)
+			database = fmt.Sprintf("%sDATABASE", withEnvPrefix)
+			user = fmt.Sprintf("%sUSER", withEnvPrefix)
+			password = fmt.Sprintf("%sPASSWORD", withEnvPrefix)
+			type_ = fmt.Sprintf("%sTYPE", withEnvPrefix)
+			schema = fmt.Sprintf("%sSCHEMA", withEnvPrefix)
+			dbtProfile = fmt.Sprintf("%sDBT_PROFILE", withEnvPrefix)
+			useDbtProfiles = fmt.Sprintf("%sUSE_DBT_PROFILES", withEnvPrefix)
+			dbtProfilesPath = fmt.Sprintf("%sDBT_PROFILES_PATH", withEnvPrefix)
 		}
 
 		if individualRows {

--- a/cmd/sqleton/cmds/db.go
+++ b/cmd/sqleton/cmds/db.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/helpers/maps"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/sqleton/pkg"
+	"github.com/jmoiron/sqlx"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
@@ -67,7 +68,9 @@ var dbTestConnectionCmd = &cobra.Command{
 		cobra.CheckErr(err)
 
 		cobra.CheckErr(err)
-		defer db.Close()
+		defer func(db *sqlx.DB) {
+			_ = db.Close()
+		}(db)
 
 		err = db.Ping()
 		cobra.CheckErr(err)
@@ -89,7 +92,9 @@ var dbTestConnectionCmdWithPrefix = &cobra.Command{
 		cobra.CheckErr(err)
 
 		cobra.CheckErr(err)
-		defer db.Close()
+		defer func(db *sqlx.DB) {
+			_ = db.Close()
+		}(db)
 
 		err = db.Ping()
 		cobra.CheckErr(err)
@@ -146,6 +151,154 @@ var dbPrintEvidenceSettingsCmd = &cobra.Command{
 	},
 }
 
+var dbPrintEnvCmd = &cobra.Command{
+	Use:   "print-env",
+	Short: "Output the settings to connect to a database as environment variables",
+	Run: func(cmd *cobra.Command, args []string) {
+		config := createConfigFromCobra(cmd)
+		source, err := config.GetSource()
+		cobra.CheckErr(err)
+
+		isEnvRc, _ := cmd.Flags().GetBool("envrc")
+		envPrefix, _ := cmd.Flags().GetString("env-prefix")
+
+		prefix := ""
+		if isEnvRc {
+			prefix = "export "
+		}
+		prefix = prefix + envPrefix
+		fmt.Printf("%s%s=%s\n", prefix, "TYPE", source.Type)
+		fmt.Printf("%s%s=%s\n", prefix, "HOST", source.Hostname)
+		fmt.Printf("%s%s=%s\n", prefix, "PORT", fmt.Sprintf("%d", source.Port))
+		fmt.Printf("%s%s=%s\n", prefix, "DATABASE", source.Database)
+		fmt.Printf("%s%s=%s\n", prefix, "USER", source.Username)
+		fmt.Printf("%s%s=%s\n", prefix, "PASSWORD", source.Password)
+		fmt.Printf("%s%s=%s\n", prefix, "SCHEMA", source.Schema)
+		fmt.Printf("%s%s=%s\n", prefix, "USE_DBT_PROFILES", config.UseDbtProfiles)
+		fmt.Printf("%s%s=%s\n", prefix, "DBT_PROFILES_PATH", config.DbtProfilesPath)
+		fmt.Printf("%s%s=%s\n", prefix, "DBT_PROFILE", config.DbtProfile)
+	},
+}
+
+var dbPrintSettingsCmd = &cobra.Command{
+	Use:   "print-settings",
+	Short: "Output the settings to connect to a database using glazed",
+	Run: func(cmd *cobra.Command, args []string) {
+		config := createConfigFromCobra(cmd)
+		source, err := config.GetSource()
+		cobra.CheckErr(err)
+
+		gp, err := cli.CreateGlazedProcessorFromCobra(cmd)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Could not create glaze  procersors: %v\n", err)
+			os.Exit(1)
+		}
+
+		individualRows, _ := cmd.Flags().GetBool("individual-rows")
+		useSqletonEnvNames, _ := cmd.Flags().GetBool("use-env-names")
+		withEnvPrefix, _ := cmd.Flags().GetString("with-env-prefix")
+
+		ctx := cmd.Context()
+
+		host := "host"
+		port := "port"
+		database := "database"
+		user := "user"
+		password := "password"
+		type_ := "type"
+		schema := "schema"
+		dbtProfile := "dbtProfile"
+		useDbtProfiles := "useDbtProfiles"
+		dbtProfilesPath := "dbtProfilesPath"
+
+		if useSqletonEnvNames {
+			host = "SQLETON_HOST"
+			port = "SQLETON_PORT"
+			database = "SQLETON_DATABASE"
+			user = "SQLETON_USER"
+			password = "SQLETON_PASSWORD"
+			type_ = "SQLETON_TYPE"
+			schema = "SQLETON_SCHEMA"
+			dbtProfile = "SQLETON_DBT_PROFILE"
+			useDbtProfiles = "SQLETON_USE_DBT_PROFILES"
+			dbtProfilesPath = "SQLETON_DBT_PROFILES_PATH"
+		} else if withEnvPrefix != "" {
+			host = fmt.Sprintf("%s_HOST", withEnvPrefix)
+			port = fmt.Sprintf("%s_PORT", withEnvPrefix)
+			database = fmt.Sprintf("%s_DATABASE", withEnvPrefix)
+			user = fmt.Sprintf("%s_USER", withEnvPrefix)
+			password = fmt.Sprintf("%s_PASSWORD", withEnvPrefix)
+			type_ = fmt.Sprintf("%s_TYPE", withEnvPrefix)
+			schema = fmt.Sprintf("%s_SCHEMA", withEnvPrefix)
+			dbtProfile = fmt.Sprintf("%s_DBT_PROFILE", withEnvPrefix)
+			useDbtProfiles = fmt.Sprintf("%s_USE_DBT_PROFILES", withEnvPrefix)
+			dbtProfilesPath = fmt.Sprintf("%s_DBT_PROFILES_PATH", withEnvPrefix)
+		}
+
+		if individualRows {
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  host,
+				"value": source.Hostname,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  port,
+				"value": source.Port,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  database,
+				"value": source.Database,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  user,
+				"value": source.Username,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  password,
+				"value": source.Password,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  type_,
+				"value": source.Type,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  schema,
+				"value": source.Schema,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  dbtProfile,
+				"value": config.DbtProfile,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  useDbtProfiles,
+				"value": config.UseDbtProfiles,
+			})
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				"name":  dbtProfilesPath,
+				"value": config.DbtProfilesPath,
+			})
+		} else {
+			_ = gp.ProcessInputObject(ctx, map[string]interface{}{
+				host:            source.Hostname,
+				port:            source.Port,
+				database:        source.Database,
+				user:            source.Username,
+				password:        source.Password,
+				type_:           source.Type,
+				schema:          source.Schema,
+				dbtProfile:      config.DbtProfile,
+				useDbtProfiles:  config.UseDbtProfiles,
+				dbtProfilesPath: config.DbtProfilesPath,
+			})
+		}
+
+		err = gp.OutputFormatter().Output(ctx, os.Stdout)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error rendering output: %s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 var dbLsCmd = &cobra.Command{
 	Use:   "ls",
 	Short: "List databases from profiles",
@@ -189,12 +342,9 @@ var dbLsCmd = &cobra.Command{
 }
 
 func init() {
-	DbCmd.AddCommand(dbLsCmd)
-
 	err := cli.AddGlazedProcessorFlagsToCobraCommand(dbLsCmd)
-	if err != nil {
-		panic(err)
-	}
+	cobra.CheckErr(err)
+	DbCmd.AddCommand(dbLsCmd)
 
 	connectionLayer, err := pkg.NewSqlConnectionParameterLayer()
 	cobra.CheckErr(err)
@@ -212,6 +362,21 @@ func init() {
 	cobra.CheckErr(err)
 	dbPrintEvidenceSettingsCmd.Flags().String("git-repo", "", "Git repo to use for evidence.dev")
 	DbCmd.AddCommand(dbPrintEvidenceSettingsCmd)
+
+	err = connectionLayer.AddFlagsToCobraCommand(dbPrintEnvCmd)
+	cobra.CheckErr(err)
+	dbPrintEnvCmd.Flags().Bool("envrc", false, "Output as an .envrc file")
+	dbPrintEnvCmd.Flags().String("env-prefix", "SQLETON_", "Prefix for environment variables")
+	DbCmd.AddCommand(dbPrintEnvCmd)
+
+	err = connectionLayer.AddFlagsToCobraCommand(dbPrintSettingsCmd)
+	cobra.CheckErr(err)
+	dbPrintSettingsCmd.Flags().Bool("individual-rows", false, "Output as individual rows")
+	dbPrintSettingsCmd.Flags().String("with-env-prefix", "", "Output as environment variables with a prefix")
+	dbPrintSettingsCmd.Flags().Bool("use-env-names", false, "Output as SQLETON_ environment variables with a prefix")
+	err = cli.AddGlazedProcessorFlagsToCobraCommand(dbPrintSettingsCmd)
+	cobra.CheckErr(err)
+	DbCmd.AddCommand(dbPrintSettingsCmd)
 
 	connectionLayer, err = pkg.NewSqlConnectionParameterLayer(
 		layers.WithPrefix("test-"),

--- a/cmd/sqleton/doc/topics/05-print-settings.md
+++ b/cmd/sqleton/doc/topics/05-print-settings.md
@@ -1,0 +1,173 @@
+---
+Title: Printing connection settings
+Slug: print-settings
+Short: |
+  You can print out the currently configured connection settings for quick
+  reuse in an env file or other configuration file.
+Topics:
+  - settings
+Commands:
+  - print-env
+  - print-evidence-settings
+  - print-settings
+IsTemplate: false
+IsTopLevel: true
+ShowPerDefault: false
+SectionType: GeneralTopic
+---
+
+## Printing settings
+
+The connection settings for sqleton can be passed in through a variety of ways.
+They can be passed as environment flags, as command line flags, as a config file,
+and event as a dbt profile.
+
+Sometimes, these credentials need to be partially or fully exported for use in another
+application (say, a docker-compose file, an env file, a JSON for a cloud deploy).
+In order to facilitate the often tedious process, sqleton provides the following commands
+to make a developer's life easier.
+
+### `sqleton db print-env`
+
+This command prints out the connection settings as environment variables. It is
+useful for quickly exporting the settings to an env file.
+
+```
+❯ sqleton db print-env
+SQLETON_TYPE=mysql
+SQLETON_HOST=localhost
+SQLETON_PORT=3306
+SQLETON_DATABASE=sqleton
+SQLETON_USER=sqleton
+SQLETON_PASSWORD=secret
+SQLETON_SCHEMA=bones
+SQLETON_USE_DBT_PROFILES=
+SQLETON_DBT_PROFILES_PATH=
+SQLETON_DBT_PROFILE=yolo.bolo
+```
+
+Note that this will print out both connection settings and dbt settings. The dbt settings override the 
+connection settings. It is up to you to clean the output up.
+
+You can specify a different env variable name prefix.
+
+```
+❯ sqleton db print-env --env-prefix DB_
+DB_TYPE=mysql
+DB_HOST=localhost
+DB_PORT=3306
+DB_DATABASE=sqleton
+DB_USER=sqleton
+DB_PASSWORD=secret
+DB_SCHEMA=bones
+DB_USE_DBT_PROFILES=
+DB_DBT_PROFILES_PATH=
+DB_DBT_PROFILE=yolo.bolo
+```
+
+Furthermore, you can add `export ` at the beginning of each line by passing in the `--envrc` flag.
+This makes it easier to use in `.envrc` files for the `direnv` tool.
+
+```
+❯ sqleton db print-env --envrc
+export SQLETON_TYPE=mysql
+export SQLETON_HOST=localhost
+export SQLETON_PORT=3306
+export SQLETON_DATABASE=sqleton
+export SQLETON_USER=sqleton
+export SQLETON_PASSWORD=secret
+export SQLETON_SCHEMA=bones
+export SQLETON_USE_DBT_PROFILES=
+export SQLETON_DBT_PROFILES_PATH=
+export SQLETON_DBT_PROFILE=yolo.bolo
+```
+
+### `sqleton db print-settings`
+
+For a more flexible output, you can use the `print-settings` command. This command uses the glazed
+library to output the connection settings, which allows you to specify the output format.
+
+Per default, it will output the connection settings as a single row as a human readable table.
+
+```
+❯ sqleton db print-settings 
++---------+----------+-------+------------+-----------------+----------------+--------+----------+-----------+------+
+| user    | password | type  | dbtProfile | dbtProfilesPath | useDbtProfiles | schema | database | host      | port |
++---------+----------+-------+------------+-----------------+----------------+--------+----------+-----------+------+
+| sqleton | secret   | mysql | yolo.bolo  |                 | false          | bones  | sqleton  | localhost | 3306 |
++---------+----------+-------+------------+-----------------+----------------+--------+----------+-----------+------+
+```
+
+You can now easily print it as JSON or YAML.
+
+``` 
+❯ sqleton db print-settings --output yaml
+- database: sqleton
+  dbtProfile: yolo.bolo
+  dbtProfilesPath: ""
+  host: localhost
+  password: secret
+  port: 3306
+  schema: bones
+  type: mysql
+  useDbtProfiles: false
+  user: sqleton
+```
+
+You can also output each setting as a single row, for example as CSV.
+
+```
+❯ sqleton db print-settings --output csv --individual-rows
+value,name
+localhost,host
+3306,port
+sqleton,database
+sqleton,user
+secret,password
+mysql,type
+bones,schema
+yolo.bolo,dbtProfile
+false,useDbtProfiles
+,dbtProfilesPath
+```
+
+Here too, you can specify printing things out as environment variables.
+
+``` 
+❯ sqleton db print-settings --use-env-names --individual-rows
++---------------------------+-----------+
+| name                      | value     |
++---------------------------+-----------+
+| SQLETON_HOST              | localhost |
+| SQLETON_PORT              | 3306      |
+| SQLETON_DATABASE          | sqleton   |
+| SQLETON_USER              | sqleton   |
+| SQLETON_PASSWORD          | secret    |
+| SQLETON_TYPE              | mysql     |
+| SQLETON_SCHEMA            | bones     |
+| SQLETON_DBT_PROFILE       | yolo.bolo |
+| SQLETON_USE_DBT_PROFILES  | false     |
+| SQLETON_DBT_PROFILES_PATH |           |
++---------------------------+-----------+
+```
+
+The environment variables prefix can be configured as well.
+
+``` 
+❯ sqleton db print-settings --individual-rows --with-env-prefix DB_ 
++----------------------+-----------+
+| name                 | value     |
++----------------------+-----------+
+| DB_HOST              | localhost |
+| DB_PORT              | 3306      |
+| DB_DATABASE          | sqleton   |
+| DB_USER              | sqleton   |
+| DB_PASSWORD          | secret    |
+| DB_TYPE              | mysql     |
+| DB_SCHEMA            | bones     |
+| DB_DBT_PROFILE       | yolo.bolo |
+| DB_USE_DBT_PROFILES  | false     |
+| DB_DBT_PROFILES_PATH |           |
++----------------------+-----------+
+```
+

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/gin-gonic/gin v1.9.0
-	github.com/go-go-golems/clay v0.0.15
-	github.com/go-go-golems/glazed v0.2.79
+	github.com/go-go-golems/clay v0.0.16
+	github.com/go-go-golems/glazed v0.2.80
 	github.com/go-go-golems/parka v0.2.26
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/huandu/go-sqlbuilder v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -109,10 +109,10 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/clay v0.0.15 h1:8IFnBCSbcc/zY5vWYlH7q5QJYtlUt1eJjoBrI4MThtc=
-github.com/go-go-golems/clay v0.0.15/go.mod h1:7YzYY8DOykQmO3fSW045GI40LWCt0fPssq9ZtIADm+w=
-github.com/go-go-golems/glazed v0.2.79 h1:iwMU98otIyMerA9kx7F1+n+pru+m1U42ZWB7UjR3y9c=
-github.com/go-go-golems/glazed v0.2.79/go.mod h1:xYq7afZXGsPj6jS0ZyzCLTENZlIl7vGush2vCSufnNs=
+github.com/go-go-golems/clay v0.0.16 h1:d2UrE/iBg7j3lhjNMd50bGrX2LmhM0+wXEj6NMVYmnM=
+github.com/go-go-golems/clay v0.0.16/go.mod h1:8EV5qZmhX/2B9xPBzmsF/x2Bw/9SWQLqyolflH4aq3U=
+github.com/go-go-golems/glazed v0.2.80 h1:3C+PQdn3G7lQbyU4aspvasL0KdFoBkd9yYjhYkSjmas=
+github.com/go-go-golems/glazed v0.2.80/go.mod h1:xYq7afZXGsPj6jS0ZyzCLTENZlIl7vGush2vCSufnNs=
 github.com/go-go-golems/parka v0.2.26 h1:M1rQa+dduKzo+XHKgu/fQ1CyJ581xkKLC0/TzTKiUFY=
 github.com/go-go-golems/parka v0.2.26/go.mod h1:MKMD8bQO+ghc7eKKeokeX9IcgHHStKdzRe2IReOKMAo=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=


### PR DESCRIPTION
Adds commands for printing out settings for use in further configuration files and for general convenience.

- :sparkles: Add commands print-env and print-settings to output connection settings
- :art: :bulb: Add documentation for printing settings
- :arrow_up: Bump glazed

Closes #149 