### PR TITLE
:art: Minor changes to support and test the new CommandDir config file options

### DIFF
--- a/cmd/sqleton/cmds/serve.go
+++ b/cmd/sqleton/cmds/serve.go
@@ -117,7 +117,7 @@ func (s *ServeCommand) runWithConfigFile(
 	// - gather server options
 	//   - [x] port, address, gzip (passed in through the call)
 	//   - [x] static paths (from embedFS static/) -> can be done through normal option
-	//   - default parka static paths: /dist from GetParkaStaticFS
+	//   - default parka static paths: /dist from GetParkaStaticHttpFS
 	//   - favicon.ico from embeddedFiles templates/favicon.ico
 	//
 	// for the config file handler:

--- a/cmd/sqleton/cmds/serve.go
+++ b/cmd/sqleton/cmds/serve.go
@@ -80,11 +80,11 @@ func (s *ServeCommand) runWithConfigFile(
 	devMode := ps["dev"].(bool)
 	commandDirHandlerOptions = append(
 		commandDirHandlerOptions,
-		command_dir.WithReplaceOverrideLayer(
+		command_dir.WithLayerDefaults(
 			sqletonConnectionLayer.Layer.GetSlug(),
 			sqletonConnectionLayer.Parameters,
 		),
-		command_dir.WithReplaceOverrideLayer(
+		command_dir.WithLayerDefaults(
 			dbtConnectionLayer.Layer.GetSlug(),
 			dbtConnectionLayer.Parameters,
 		),

--- a/cmd/sqleton/cmds/serve.go
+++ b/cmd/sqleton/cmds/serve.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-go-golems/parka/pkg/handlers/config"
 	"github.com/go-go-golems/parka/pkg/handlers/template"
 	"github.com/go-go-golems/parka/pkg/handlers/template-dir"
-	"github.com/go-go-golems/parka/pkg/render"
 	"github.com/go-go-golems/parka/pkg/render/datatables"
 	"github.com/go-go-golems/parka/pkg/server"
 	"github.com/go-go-golems/parka/pkg/utils/fs"
@@ -94,20 +93,13 @@ func (s *ServeCommand) runWithConfigFile(
 		command_dir.WithDevMode(devMode),
 	)
 
-	parkaDefaultRendererOptions, err := server.GetDefaultParkaRendererOptions()
-	if err != nil {
-		return err
-	}
-
 	templateDirHandlerOptions = append(
 		// pass in the default parka renderer options for being able to render markdown files
 		templateDirHandlerOptions,
-		template_dir.WithAppendRendererOptions(parkaDefaultRendererOptions...),
 		template_dir.WithAlwaysReload(devMode),
 	)
 
 	templateHandlerOptions := []template.TemplateHandlerOption{
-		template.WithAppendRendererOptions(parkaDefaultRendererOptions...),
 		template.WithAlwaysReload(devMode),
 	}
 
@@ -203,7 +195,6 @@ func (s *ServeCommand) Run(
 	}
 
 	// static paths
-	sqletonRendererOptions := []render.RendererOption{}
 	if dev {
 		configFile.Routes = append(configFile.Routes, &config.Route{
 			Path: "/static",
@@ -219,10 +210,6 @@ func (s *ServeCommand) Run(
 			),
 		)
 	}
-
-	serverOptions = append(serverOptions,
-		server.WithDefaultParkaStaticPaths(),
-	)
 
 	server_, err := server.NewServer(serverOptions...)
 	if err != nil {
@@ -261,17 +248,14 @@ func (s *ServeCommand) Run(
 		command_dir.WithDevMode(dev),
 	}
 
-	// templateDirHandlerOptions
-	parkaDefaultRendererOptions, err := server.GetDefaultParkaRendererOptions()
-	if err != nil {
-		return fmt.Errorf("failed to get default parka renderer options: %w", err)
+	templateDirHandlerOptions := []template_dir.TemplateDirHandlerOption{
+		// add lookup functions for data-tables.tmpl.html and others
+		template_dir.WithAlwaysReload(dev),
 	}
 
-	templateDirHandlerOptions := []template_dir.TemplateDirHandlerOption{
-		template_dir.WithAppendRendererOptions(parkaDefaultRendererOptions...),
-		// add lookup functions for data-tables.tmpl.html and others
-		template_dir.WithAppendRendererOptions(sqletonRendererOptions...),
-		template_dir.WithAlwaysReload(dev),
+	err = configFile.Initialize()
+	if err != nil {
+		return err
 	}
 
 	cfh := handlers.NewConfigFileHandler(

--- a/cmd/sqleton/cmds/test-config-explicit-renderer.yaml
+++ b/cmd/sqleton/cmds/test-config-explicit-renderer.yaml
@@ -1,0 +1,33 @@
+routes:
+  # landing page
+  - path: /
+    template:
+      templateFile: ~/code/ttc/ttc/sql/sqleton/index.analytics.md
+  # content pages
+  - path: /
+    templateDirectory:
+      localDirectory: ~/code/ttc/ttc/sql/sqleton
+  # static content
+  - path: /static
+    static:
+      localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/static
+  #  - path: /dist
+  #    static:
+  #      localPath: ~/code/wesen/corporate-headquarters/parka/pkg/server/web/dist
+  # commands
+  - path: /
+    commandDirectory:
+      repositories:
+        - ~/.sqleton/repositories
+        - ~/code/ttc/ttc/sql/sqleton
+      # maybe we could allow multiple directories here
+      # we also need to find a syntax to add embedded or default template lookup options
+      templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+
+      # need to pass template path here
+      # localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/templates
+defaults:
+  renderer:
+    templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/server/web/src/templates
+    markdownBaseTemplateName: base.tmpl.html
+

--- a/cmd/sqleton/cmds/test-config-no-renderer.yaml
+++ b/cmd/sqleton/cmds/test-config-no-renderer.yaml
@@ -1,0 +1,30 @@
+routes:
+  # landing page
+  - path: /
+    template:
+      templateFile: ~/code/ttc/ttc/sql/sqleton/index.analytics.md
+  # content pages
+  - path: /
+    templateDirectory:
+      localDirectory: ~/code/ttc/ttc/sql/sqleton
+  # static content
+  - path: /static
+    static:
+      localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/static
+  # commands
+  - path: /
+    commandDirectory:
+      repositories:
+        - ~/.sqleton/repositories
+        - ~/code/ttc/ttc/sql/sqleton
+      # maybe we could allow multiple directories here
+      # we also need to find a syntax to add embedded or default template lookup options
+      templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+
+      # need to pass template path here
+      # localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/templates
+defaults:
+  renderer:
+    useDefaultParkaRenderer: false
+
+

--- a/cmd/sqleton/cmds/test-config-no-static.yaml
+++ b/cmd/sqleton/cmds/test-config-no-static.yaml
@@ -11,9 +11,6 @@ routes:
   - path: /static
     static:
       localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/static
-#  - path: /dist
-#    static:
-#      localPath: ~/code/wesen/corporate-headquarters/parka/pkg/server/web/dist
   # commands
   - path: /
     commandDirectory:
@@ -26,5 +23,7 @@ routes:
 
       # need to pass template path here
       # localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/templates
+defaults:
+  useParkaStaticFiles: false
 
 

--- a/cmd/sqleton/cmds/test-config-simplest.yaml
+++ b/cmd/sqleton/cmds/test-config-simplest.yaml
@@ -1,0 +1,13 @@
+routes:
+  # landing page
+  - path: /
+    template:
+      templateFile: ~/code/ttc/ttc/sql/sqleton/index.analytics.md
+  # content pages
+  - path: /
+    templateDirectory:
+      localDirectory: ~/code/ttc/ttc/sql/sqleton
+  # commands
+  - path: /
+    commandDirectory:
+      includeDefaultRepositories: true

--- a/cmd/sqleton/cmds/test-config.yaml
+++ b/cmd/sqleton/cmds/test-config.yaml
@@ -40,6 +40,11 @@ routes:
               - sales_usd
       additionalData:
         foobar: baz
+  - path: /analytics
+    commandDirectory:
+      includeDefaultRepositories: false
+      repositories:
+        - ~/code/ttc/ttc/sql/sqleton
   - path: /foobar
     commandDirectory:
       repositories:

--- a/cmd/sqleton/cmds/test-config.yaml
+++ b/cmd/sqleton/cmds/test-config.yaml
@@ -11,18 +11,17 @@ routes:
   - path: /static
     static:
       localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/static
-#  - path: /dist
-#    static:
-#      localPath: ~/code/wesen/corporate-headquarters/parka/pkg/server/web/dist
   # commands
   - path: /
     commandDirectory:
+      includeDefaultRepositories: true
       repositories:
-        - ~/.sqleton/repositories
         - ~/code/ttc/ttc/sql/sqleton
-      # maybe we could allow multiple directories here
-      # we also need to find a syntax to add embedded or default template lookup options
-      templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+
+      templateLookup:
+        directories:
+          - ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+      indexTemplateName: index.tmpl.html
       defaults:
         flags:
           limit: 1337
@@ -39,14 +38,13 @@ routes:
             filter:
               - quantity_sold
               - sales_usd
+      additionalData:
+        foobar: baz
   - path: /foobar
     commandDirectory:
       repositories:
         - ~/.sqleton/repositories
         - ~/code/ttc/ttc/sql/sqleton
-      # maybe we could allow multiple directories here
-      # we also need to find a syntax to add embedded or default template lookup options
-      templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
       overrides:
         layers:
           dbt:
@@ -56,9 +54,6 @@ routes:
       repositories:
         - ~/.sqleton/repositories
         - ~/code/ttc/ttc/sql/sqleton
-      # maybe we could allow multiple directories here
-      # we also need to find a syntax to add embedded or default template lookup options
-      templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
       overrides:
         layers:
           dbt:

--- a/cmd/sqleton/cmds/test-config.yaml
+++ b/cmd/sqleton/cmds/test-config.yaml
@@ -23,10 +23,17 @@ routes:
       # maybe we could allow multiple directories here
       # we also need to find a syntax to add embedded or default template lookup options
       templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+      defaults:
+        flags:
+          limit: 1337
+        layers:
+          glazed:
+            filter:
+              - id
       overrides:
         layers:
           dbt:
-            dbt-profile: ttc.prod
+            dbt-profile: ttc.analytics
           glazed:
             # these don't work yet because of the lack of row level middleware (which would apply the filtering)
             filter:
@@ -44,7 +51,7 @@ routes:
         layers:
           dbt:
             dbt-profile: ttc.foobar
-  - path: /analytics
+  - path: /prod
     commandDirectory:
       repositories:
         - ~/.sqleton/repositories
@@ -55,7 +62,7 @@ routes:
       overrides:
         layers:
           dbt:
-            dbt-profile: ttc.analytics
+            dbt-profile: ttc.prod
 
       # need to pass template path here
       # localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/templates

--- a/cmd/sqleton/cmds/test-config.yaml
+++ b/cmd/sqleton/cmds/test-config.yaml
@@ -23,6 +23,39 @@ routes:
       # maybe we could allow multiple directories here
       # we also need to find a syntax to add embedded or default template lookup options
       templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+      overrides:
+        layers:
+          dbt:
+            dbt-profile: ttc.prod
+          glazed:
+            # these don't work yet because of the lack of row level middleware (which would apply the filtering)
+            filter:
+              - quantity_sold
+              - sales_usd
+  - path: /foobar
+    commandDirectory:
+      repositories:
+        - ~/.sqleton/repositories
+        - ~/code/ttc/ttc/sql/sqleton
+      # maybe we could allow multiple directories here
+      # we also need to find a syntax to add embedded or default template lookup options
+      templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+      overrides:
+        layers:
+          dbt:
+            dbt-profile: ttc.foobar
+  - path: /analytics
+    commandDirectory:
+      repositories:
+        - ~/.sqleton/repositories
+        - ~/code/ttc/ttc/sql/sqleton
+      # maybe we could allow multiple directories here
+      # we also need to find a syntax to add embedded or default template lookup options
+      templateDirectory: ~/code/wesen/corporate-headquarters/parka/pkg/render/datatables/templates
+      overrides:
+        layers:
+          dbt:
+            dbt-profile: ttc.analytics
 
       # need to pass template path here
       # localPath: ~/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/templates

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/go-go-golems/clay v0.0.17
-	github.com/go-go-golems/glazed v0.2.83
-	github.com/go-go-golems/parka v0.3.1
+	github.com/go-go-golems/glazed v0.2.84
+	github.com/go-go-golems/parka v0.3.2
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/huandu/go-sqlbuilder v1.18.0
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -111,10 +111,10 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-go-golems/clay v0.0.17 h1:lFOXpAs3AiBMu3LwUO2xvJ7JvkIVU4g2beRODyKGvTM=
 github.com/go-go-golems/clay v0.0.17/go.mod h1:2QM24Cz+xBFrnXr5h561DAQ/lxLYlnUO8EjlxiOsYk4=
-github.com/go-go-golems/glazed v0.2.83 h1:oIHaJdjtS95Qv1rD8uka5Md/UD9S9ClHXa5YMaTzjng=
-github.com/go-go-golems/glazed v0.2.83/go.mod h1:wlKdrmjongDOf2gqPVd8OwPVp50PVgWyv65mhxcEkP0=
-github.com/go-go-golems/parka v0.3.1 h1:RwlJ8sUk8ROWUEddTciUph/FlkJgleqsugu1NHJztCU=
-github.com/go-go-golems/parka v0.3.1/go.mod h1:y5dsC/US3TjVDeBYBYPey9pX3Ih0encFAm0c1Witsew=
+github.com/go-go-golems/glazed v0.2.84 h1:rZylJBh/ZrD1Hi4xWXGf5cFQAWbLK9C9FbB426ASWhU=
+github.com/go-go-golems/glazed v0.2.84/go.mod h1:wlKdrmjongDOf2gqPVd8OwPVp50PVgWyv65mhxcEkP0=
+github.com/go-go-golems/parka v0.3.2 h1:0e2n9aUhmKKTWn0ntZdZdw2bl6oynNDxsvMrDgtVus8=
+github.com/go-go-golems/parka v0.3.2/go.mod h1:/qaBTstby1EK3OI1OHzWg5175tRx8/YSsJWtcf0IBVA=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/sql.go
+++ b/pkg/sql.go
@@ -134,7 +134,9 @@ func (s *SqlCommand) Run(
 	if err != nil {
 		return err
 	}
-	defer db.Close()
+	defer func(db *sqlx.DB) {
+		_ = db.Close()
+	}(db)
 
 	err = db.PingContext(ctx)
 	if err != nil {


### PR DESCRIPTION
- :art: Add test config file using default parka FS
- :art: Use DefaultRenderer configuration using the config file
- :art: Add test config file to set explicit renderer options
- :pencil: Add minor explicit error ignoring
- :art: Set layer defaults for sql override
- :sparkles: Add method to render query directly without having to instantiate the connection
- :pencil: Add testing of defaults in test-config.yaml
- :art: Add test config for minimal config
- :art: Add a simple mount point to test BasePath property
- :arrow_up: Bump glazed and parka
