### PR TITLE
Implement code generation from Sqleton YAML to Go

### DIFF
--- a/cmd/sqleton/cmds/codegen.go
+++ b/cmd/sqleton/cmds/codegen.go
@@ -1,0 +1,67 @@
+package cmds
+
+import (
+	"bytes"
+	"fmt"
+	cmds2 "github.com/go-go-golems/sqleton/pkg/cmds"
+	"github.com/go-go-golems/sqleton/pkg/codegen"
+	"github.com/spf13/cobra"
+	"os"
+	"path"
+	"strings"
+)
+
+func NewCodegenCommand() *cobra.Command {
+	ret := &cobra.Command{
+		Use:   "codegen [file...]",
+		Short: "A program to convert Sqleton YAML commands into Go code",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			packageName := cmd.Flag("package-name").Value.String()
+			outputDir := cmd.Flag("output-dir").Value.String()
+
+			s := &codegen.SqlCommandCodeGenerator{
+				PackageName: packageName,
+			}
+
+			for _, fileName := range args {
+				psYaml, err := os.ReadFile(fileName)
+				if err != nil {
+					return err
+				}
+
+				loader := &cmds2.SqlCommandLoader{
+					DBConnectionFactory: nil,
+				}
+
+				// create reader from psYaml
+				r := bytes.NewReader(psYaml)
+				cmds_, err := loader.LoadCommandFromYAML(r)
+				if err != nil {
+					return err
+				}
+				if len(cmds_) != 1 {
+					return fmt.Errorf("expected exactly one command, got %d", len(cmds_))
+				}
+				cmd := cmds_[0].(*cmds2.SqlCommand)
+
+				f := s.GenerateCommandCode(cmd)
+
+				s := f.GoString()
+				// store in path.go after removing .yaml
+				p, _ := strings.CutSuffix(path.Base(fileName), ".yaml")
+				p = p + ".go"
+				p = path.Join(outputDir, p)
+
+				fmt.Printf("Converting %s to %s\n", fileName, p)
+				_ = os.WriteFile(p, []byte(s), 0644)
+			}
+
+			return nil
+		},
+	}
+
+	ret.PersistentFlags().StringP("output-dir", "o", ".", "Output directory for generated code")
+	ret.PersistentFlags().StringP("package-name", "p", "main", "Package name for generated code")
+	return ret
+}

--- a/cmd/sqleton/cmds/codegen.go
+++ b/cmd/sqleton/cmds/codegen.go
@@ -45,7 +45,10 @@ func NewCodegenCommand() *cobra.Command {
 				}
 				cmd := cmds_[0].(*cmds2.SqlCommand)
 
-				f := s.GenerateCommandCode(cmd)
+				f, err := s.GenerateCommandCode(cmd)
+				if err != nil {
+					return err
+				}
 
 				s := f.GoString()
 				// store in path.go after removing .yaml

--- a/cmd/sqleton/main.go
+++ b/cmd/sqleton/main.go
@@ -145,6 +145,8 @@ func initRootCmd() (*help.HelpSystem, error) {
 	cobra.CheckErr(err)
 
 	rootCmd.AddCommand(runCommandCmd)
+
+	rootCmd.AddCommand(cmds.NewCodegenCommand())
 	return helpSystem, nil
 }
 

--- a/cmd/sqleton/queries/mysql/ps.yaml
+++ b/cmd/sqleton/queries/mysql/ps.yaml
@@ -32,6 +32,10 @@ flags:
   - name: full_info
     type: bool
     help: Show the full info
+  - name: foobar
+    type: intList
+    help: Filter by foobar
+    default: [1,2,3]
 query: |
   SELECT 
   Id,User,Host,db,Command,Time,State

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -1,0 +1,136 @@
+package codegen
+
+import (
+	"github.com/dave/jennifer/jen"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/sqleton/pkg/cmds"
+	"github.com/iancoleman/strcase"
+)
+
+type SqlCommandCodeGenerator struct {
+	PackageName string
+}
+
+const SqletonCmdsPath = "github.com/go-go-golems/sqleton/pkg/cmds"
+const GlazedCommandsPath = "github.com/go-go-golems/glazed/pkg/cmds"
+const GlazedMiddlewaresPath = "github.com/go-go-golems/glazed/pkg/middlewares"
+const GlazedParametersPath = "github.com/go-go-golems/glazed/pkg/cmds/parameters"
+const ClaySqlPath = "github.com/go-go-golems/clay/pkg/sql"
+const MapsHelpersPath = "github.com/go-go-golems/glazed/pkg/helpers/maps"
+
+func (s *SqlCommandCodeGenerator) defineRunMethod(f *jen.File, cmdName string) {
+	methodName := "Run"
+	receiver := strcase.ToCamel(cmdName) + "Command"
+	parametersStruct := strcase.ToCamel(cmdName) + "CommandParameters"
+
+	f.Func().Params(jen.Id("p").Op("*").Id(receiver)).Id(methodName).
+		Params(
+			jen.Id("ctx").Qual("context", "Context"),
+			jen.Id("db").Op("*").Qual("github.com/jmoiron/sqlx", "DB"),
+			jen.Id("params").Op("*").Id(parametersStruct),
+			jen.Id("gp").Qual(GlazedMiddlewaresPath, "Processor"),
+		).Error().
+		Block(
+			jen.Id("ps").Op(":=").Qual(MapsHelpersPath, "StructToMap").Call(jen.Id("params"), jen.Lit(false)),
+			jen.List(jen.Id("renderedQuery"), jen.Err()).Op(":=").Qual(ClaySqlPath, "RenderQuery").Call(
+				jen.Id("ctx"), jen.Id("db"), jen.Id("p").Dot("Query"), jen.Id("p").Dot("SubQueries"), jen.Id("ps"),
+			),
+			jen.If(jen.Err().Op("!=").Nil()).Block(jen.Return(jen.Err())),
+			jen.Err().Op("=").Qual(ClaySqlPath, "RunQueryIntoGlaze").Call(
+				jen.Id("ctx"), jen.Id("db"), jen.Id("renderedQuery"), jen.Index().Interface().Values(), jen.Id("gp"),
+			),
+			jen.If(jen.Err().Op("!=").Nil()).Block(jen.Return(jen.Err())),
+			jen.Return(jen.Nil()),
+		)
+}
+
+func (s *SqlCommandCodeGenerator) defineNewFunction(f *jen.File, cmdName string, cmd *cmds.SqlCommand) error {
+	funcName := "New" + strcase.ToCamel(cmdName) + "Command"
+	commandStruct := strcase.ToCamel(cmdName) + "Command"
+	queryConstName := strcase.ToCamel(cmdName) + "CommandQuery"
+
+	description := cmd.Description()
+
+	var err_ error
+	f.Func().Id(funcName).Params().
+		Params(jen.Op("*").Id(commandStruct), jen.Error()).
+		Block(
+			jen.Var().Id("flagDefs").Op("=").
+				Index().Op("*").
+				Qual(GlazedParametersPath, "ParameterDefinition").
+				ValuesFunc(func(g *jen.Group) {
+					var dicts []jen.Code
+					for _, flag := range cmd.Flags {
+						dict, err := ParameterDefinitionToDict(flag)
+						if err != nil {
+							err_ = err
+							return
+						}
+						dicts = append(dicts, dict)
+					}
+
+					g.Values(dicts...)
+				}),
+			jen.Id("cmdDescription").Op(":=").Qual(GlazedCommandsPath, "NewCommandDescription").
+				Call(
+					jen.Lit(description.Name),
+					jen.Qual(GlazedCommandsPath, "WithShort").Call(jen.Lit(description.Short)),
+					jen.Qual(GlazedCommandsPath, "WithLong").Call(jen.Lit(description.Long)),
+					jen.Qual(GlazedCommandsPath, "WithFlags").Call(jen.Id("flagDefs").Op("...")),
+				),
+			jen.Return(jen.Op("&").Id(commandStruct).Values(jen.Dict{
+				jen.Id("CommandDescription"): jen.Id("cmdDescription"),
+				jen.Id("Query"):              jen.Id(queryConstName),
+				jen.Id("SubQueries"):         jen.Map(jen.String()).String().Values(),
+			}), jen.Nil()),
+		)
+
+	return err_
+}
+
+func (s *SqlCommandCodeGenerator) defineConstants(f *jen.File, cmdName string, cmd *cmds.SqlCommand) {
+	// Define the constant for the main query.
+	queryConstName := strcase.ToCamel(cmdName) + "CommandQuery"
+	f.Const().Id(queryConstName).Op("=").Lit(cmd.Query)
+	// Define constants for subqueries if they exist.
+	if len(cmd.SubQueries) > 0 {
+		for name, subQuery := range cmd.SubQueries {
+			subQueryConstName := strcase.ToCamel(cmdName) + "CommandSubQuery" + name
+			f.Const().Id(subQueryConstName).Op("=").Lit(subQuery)
+		}
+	}
+}
+
+func (s *SqlCommandCodeGenerator) defineStruct(f *jen.File, cmdName string) {
+	structName := strcase.ToCamel(cmdName) + "Command"
+	f.Type().Id(structName).Struct(
+		jen.Op("*").Qual(GlazedCommandsPath, "CommandDescription"),
+		jen.Id("Query").String().Tag(map[string]string{"yaml": "query"}),
+		jen.Id("SubQueries").Map(jen.String()).String().Tag(map[string]string{"yaml": "subqueries,omitempty"}),
+	)
+}
+
+func (s *SqlCommandCodeGenerator) defineParametersStruct(f *jen.File, cmdName string, flags []*parameters.ParameterDefinition) {
+	structName := strcase.ToCamel(cmdName) + "CommandParameters"
+	f.Type().Id(structName).StructFunc(func(g *jen.Group) {
+		for _, flag := range flags {
+			s := g.Id(strcase.ToCamel(flag.Name))
+			s = FlagTypeToGoType(s, flag.Type)
+			s.Tag(map[string]string{"glazed.parameter": strcase.ToSnake(flag.Name)})
+		}
+	})
+}
+
+func (s *SqlCommandCodeGenerator) GenerateCommandCode(cmd *cmds.SqlCommand) *jen.File {
+	f := jen.NewFile(s.PackageName)
+	cmdName := strcase.ToLowerCamel(cmd.Name)
+
+	// Define constants, struct, and methods using helper functions.
+	s.defineConstants(f, cmdName, cmd)
+	s.defineStruct(f, cmdName)
+	s.defineParametersStruct(f, cmdName, cmd.Flags)
+	s.defineRunMethod(f, cmdName)
+	s.defineNewFunction(f, cmdName, cmd)
+
+	return f
+}

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -51,15 +51,6 @@ func (s *SqlCommandCodeGenerator) defineNewFunction(f *jen.File, cmdName string,
 
 	description := cmd.Description()
 
-	var dicts []jen.Code
-	for _, flag := range cmd.Flags {
-		dict, err := ParameterDefinitionToDict(flag)
-		if err != nil {
-			return err
-		}
-		dicts = append(dicts, dict)
-	}
-
 	var err_ error
 	f.Func().Id(funcName).Params().
 		Params(jen.Op("*").Id(commandStruct), jen.Error()).

--- a/pkg/codegen/glazed.go
+++ b/pkg/codegen/glazed.go
@@ -3,7 +3,7 @@ package codegen
 import (
 	"github.com/dave/jennifer/jen"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/pkg/errors"
+	"reflect"
 )
 
 func ParameterDefinitionToDict(p *parameters.ParameterDefinition) (jen.Code, error) {
@@ -19,7 +19,6 @@ func ParameterDefinitionToDict(p *parameters.ParameterDefinition) (jen.Code, err
 		if err != nil {
 			return nil, err
 		}
-		ret[jen.Id("Default")] = jen.Lit(p.Default)
 	}
 	if p.Choices != nil {
 		ret[jen.Id("Choices")] = jen.Index().String().ValuesFunc(func(g *jen.Group) {
@@ -39,74 +38,7 @@ func FlagValueToJen(p *parameters.ParameterDefinition) (jen.Code, error) {
 	}
 
 	d := p.Default
-
-	switch p.Type {
-	case parameters.ParameterTypeFloat:
-		return jen.Lit(d.(float64)), nil
-	case parameters.ParameterTypeFloatList:
-		return jen.Index().Float64().ValuesFunc(func(g *jen.Group) {
-			for _, v := range d.([]float64) {
-				g.Lit(v)
-			}
-		}), nil
-	case parameters.ParameterTypeInteger:
-		return jen.Lit(d.(int)), nil
-	case parameters.ParameterTypeIntegerList:
-		return jen.Index().Int().ValuesFunc(func(g *jen.Group) {
-			for _, v := range d.([]int) {
-				g.Lit(v)
-			}
-		}), nil
-	case parameters.ParameterTypeBool:
-		return jen.Lit(d.(bool)), nil
-	case parameters.ParameterTypeDate:
-		t, err := parameters.ParseDate(d.(string))
-		if err != nil {
-			return nil, err
-		}
-		return jen.Qual("time", "Date").Values(jen.Dict{
-			jen.Id("Year"):  jen.Lit(t.Year()),
-			jen.Id("Month"): jen.Lit(t.Month()),
-			jen.Id("Day"):   jen.Lit(t.Day()),
-			jen.Id("Hour"):  jen.Lit(t.Hour()),
-			jen.Id("Min"):   jen.Lit(t.Minute()),
-			jen.Id("Sec"):   jen.Lit(t.Second()),
-		}), nil
-	case parameters.ParameterTypeStringFromFile,
-		parameters.ParameterTypeStringFromFiles,
-		parameters.ParameterTypeChoice,
-		parameters.ParameterTypeString:
-		return jen.Lit(d.(string)), nil
-	case parameters.ParameterTypeStringList,
-		parameters.ParameterTypeStringListFromFile,
-		parameters.ParameterTypeStringListFromFiles,
-		parameters.ParameterTypeChoiceList:
-		return jen.Index().String().ValuesFunc(func(g *jen.Group) {
-			for _, v := range d.([]string) {
-				g.Lit(v)
-			}
-		}), nil
-		//case parameters.ParameterTypeFile:
-		//	fileData, err := parameters.GetFileData(d.(string))
-		//	if err != nil {
-		//		return nil, err
-		//	}
-		//	return jen.Qual(GlazedParametersPath, "FileData").Values(jen.Dict{
-		//
-		//	}
-		//case parameters.ParameterTypeFileList:
-		//	return s.Index().Qual(GlazedParametersPath, "FileData")
-		//case parameters.ParameterTypeObjectFromFile:
-		//	return s.Map(jen.Id("string")).Id("interface{}")
-		//case parameters.ParameterTypeObjectListFromFile, parameters.ParameterTypeObjectListFromFiles:
-		//	return s.Index().Map(jen.Id("string")).Id("interface{}")
-		//case parameters.ParameterTypeKeyValue:
-		//	return s.Map(jen.Id("string")).Id("string")
-		//default:
-		//	return s.Id(string(parameterType))
-	}
-
-	return nil, errors.New("unsupported field type")
+	return LiteralToJen(reflect.ValueOf(d))
 }
 
 func FlagTypeToGoType(s *jen.Statement, parameterType parameters.ParameterType) *jen.Statement {

--- a/pkg/codegen/glazed.go
+++ b/pkg/codegen/glazed.go
@@ -1,0 +1,149 @@
+package codegen
+
+import (
+	"github.com/dave/jennifer/jen"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/pkg/errors"
+)
+
+func ParameterDefinitionToDict(p *parameters.ParameterDefinition) (jen.Code, error) {
+	ret := jen.Dict{
+		jen.Id("Name"): jen.Lit(p.Name),
+		jen.Id("Type"): jen.Lit(string(p.Type)),
+		jen.Id("Help"): jen.Lit(p.Help),
+	}
+
+	if p.Default != nil {
+		var err error
+		ret[jen.Id("Default")], err = FlagValueToJen(p)
+		if err != nil {
+			return nil, err
+		}
+		ret[jen.Id("Default")] = jen.Lit(p.Default)
+	}
+	if p.Choices != nil {
+		ret[jen.Id("Choices")] = jen.Index().String().ValuesFunc(func(g *jen.Group) {
+			for _, c := range p.Choices {
+				g.Lit(c)
+			}
+		})
+	}
+
+	return ret, nil
+}
+
+func FlagValueToJen(p *parameters.ParameterDefinition) (jen.Code, error) {
+	err := p.CheckParameterDefaultValueValidity()
+	if err != nil {
+		return nil, err
+	}
+
+	d := p.Default
+
+	switch p.Type {
+	case parameters.ParameterTypeFloat:
+		return jen.Lit(d.(float64)), nil
+	case parameters.ParameterTypeFloatList:
+		return jen.Index().Float64().ValuesFunc(func(g *jen.Group) {
+			for _, v := range d.([]float64) {
+				g.Lit(v)
+			}
+		}), nil
+	case parameters.ParameterTypeInteger:
+		return jen.Lit(d.(int)), nil
+	case parameters.ParameterTypeIntegerList:
+		return jen.Index().Int().ValuesFunc(func(g *jen.Group) {
+			for _, v := range d.([]int) {
+				g.Lit(v)
+			}
+		}), nil
+	case parameters.ParameterTypeBool:
+		return jen.Lit(d.(bool)), nil
+	case parameters.ParameterTypeDate:
+		t, err := parameters.ParseDate(d.(string))
+		if err != nil {
+			return nil, err
+		}
+		return jen.Qual("time", "Date").Values(jen.Dict{
+			jen.Id("Year"):  jen.Lit(t.Year()),
+			jen.Id("Month"): jen.Lit(t.Month()),
+			jen.Id("Day"):   jen.Lit(t.Day()),
+			jen.Id("Hour"):  jen.Lit(t.Hour()),
+			jen.Id("Min"):   jen.Lit(t.Minute()),
+			jen.Id("Sec"):   jen.Lit(t.Second()),
+		}), nil
+	case parameters.ParameterTypeStringFromFile,
+		parameters.ParameterTypeStringFromFiles,
+		parameters.ParameterTypeChoice,
+		parameters.ParameterTypeString:
+		return jen.Lit(d.(string)), nil
+	case parameters.ParameterTypeStringList,
+		parameters.ParameterTypeStringListFromFile,
+		parameters.ParameterTypeStringListFromFiles,
+		parameters.ParameterTypeChoiceList:
+		return jen.Index().String().ValuesFunc(func(g *jen.Group) {
+			for _, v := range d.([]string) {
+				g.Lit(v)
+			}
+		}), nil
+		//case parameters.ParameterTypeFile:
+		//	fileData, err := parameters.GetFileData(d.(string))
+		//	if err != nil {
+		//		return nil, err
+		//	}
+		//	return jen.Qual(GlazedParametersPath, "FileData").Values(jen.Dict{
+		//
+		//	}
+		//case parameters.ParameterTypeFileList:
+		//	return s.Index().Qual(GlazedParametersPath, "FileData")
+		//case parameters.ParameterTypeObjectFromFile:
+		//	return s.Map(jen.Id("string")).Id("interface{}")
+		//case parameters.ParameterTypeObjectListFromFile, parameters.ParameterTypeObjectListFromFiles:
+		//	return s.Index().Map(jen.Id("string")).Id("interface{}")
+		//case parameters.ParameterTypeKeyValue:
+		//	return s.Map(jen.Id("string")).Id("string")
+		//default:
+		//	return s.Id(string(parameterType))
+	}
+
+	return nil, errors.New("unsupported field type")
+}
+
+func FlagTypeToGoType(s *jen.Statement, parameterType parameters.ParameterType) *jen.Statement {
+	switch parameterType {
+	case parameters.ParameterTypeFloat:
+		return s.Id("float64")
+	case parameters.ParameterTypeFloatList:
+		return s.Index().Id("float64")
+	case parameters.ParameterTypeInteger:
+		return s.Id("int")
+	case parameters.ParameterTypeIntegerList:
+		return s.Index().Id("int")
+	case parameters.ParameterTypeBool:
+		return s.Id("bool")
+	case parameters.ParameterTypeDate:
+		return s.Qual("time", "Time")
+	case parameters.ParameterTypeStringFromFile,
+		parameters.ParameterTypeStringFromFiles,
+		parameters.ParameterTypeChoice,
+		parameters.ParameterTypeString:
+		return s.Id("string")
+	case parameters.ParameterTypeStringList,
+		parameters.ParameterTypeStringListFromFile,
+		parameters.ParameterTypeStringListFromFiles,
+		parameters.ParameterTypeChoiceList:
+		return s.Index().Id("string")
+	case parameters.ParameterTypeFile:
+		return s.Qual(GlazedParametersPath, "FileData")
+	case parameters.ParameterTypeFileList:
+		return s.Index().Qual(GlazedParametersPath, "FileData")
+	case parameters.ParameterTypeObjectFromFile:
+		return s.Map(jen.Id("string")).Id("interface{}")
+	case parameters.ParameterTypeObjectListFromFile, parameters.ParameterTypeObjectListFromFiles:
+		return s.Index().Map(jen.Id("string")).Id("interface{}")
+	case parameters.ParameterTypeKeyValue:
+		return s.Map(jen.Id("string")).Id("string")
+	default:
+		return s.Id(string(parameterType))
+	}
+}

--- a/pkg/codegen/helpers.go
+++ b/pkg/codegen/helpers.go
@@ -46,6 +46,7 @@ func StructTypeToJen(typ reflect.Type) (jen.Code, error) {
 
 // TypeToJen converts a reflect.Type to jen.Code
 func TypeToJen(t reflect.Type) (jen.Code, error) {
+	//nolint: exhaustive
 	switch t.Kind() {
 	case reflect.String:
 		return jen.String(), nil
@@ -130,6 +131,8 @@ func StructValueToJen(structName string, s interface{}) (jen.Code, error) {
 }
 
 func LiteralToJen(v reflect.Value) (jen.Code, error) {
+
+	//nolint:exhaustive
 	switch v.Kind() {
 	case reflect.String:
 		return jen.Lit(v.String()), nil

--- a/pkg/codegen/helpers.go
+++ b/pkg/codegen/helpers.go
@@ -1,0 +1,258 @@
+package codegen
+
+import (
+	"github.com/dave/jennifer/jen"
+	"github.com/pkg/errors"
+	"reflect"
+)
+
+func StructTypeToJen(typ reflect.Type) (jen.Code, error) {
+	isPointer := typ.Kind() == reflect.Ptr
+	if isPointer {
+		typ = typ.Elem()
+	}
+
+	if typ.Kind() != reflect.Struct {
+		return nil, errors.New("input is not a struct")
+	}
+
+	var err error
+	ret := jen.StructFunc(func(g *jen.Group) {
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			fieldType := field.Type
+
+			jenType, err_ := TypeToJen(fieldType)
+			if err_ != nil {
+				err = err_
+				return
+			}
+
+			g.Id(field.Name).Add(jenType)
+		}
+	})
+
+	// found an error while generating the struct
+	if err != nil {
+		return nil, err
+	}
+
+	if isPointer {
+		ret = jen.Op("*").Add(ret)
+	}
+
+	return ret, nil
+}
+
+// TypeToJen converts a reflect.Type to jen.Code
+func TypeToJen(t reflect.Type) (jen.Code, error) {
+	switch t.Kind() {
+	case reflect.String:
+		return jen.String(), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return jen.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return jen.Uint(), nil
+	case reflect.Float32, reflect.Float64:
+		return jen.Float64(), nil
+	case reflect.Bool:
+		return jen.Bool(), nil
+	case reflect.Ptr:
+		elemType, err := TypeToJen(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		return jen.Op("*").Add(elemType), nil
+	case reflect.Struct:
+		c, err := StructTypeToJen(t)
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	case reflect.Array, reflect.Slice:
+		elemType, err := TypeToJen(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		return jen.Index().Add(elemType), nil
+	case reflect.Map:
+		keyType, err := TypeToJen(t.Key())
+		if err != nil {
+			return nil, err
+		}
+		elemType, err := TypeToJen(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		return jen.Map(keyType).Add(elemType), nil
+	case reflect.Interface:
+		return jen.Interface(), nil
+	default:
+		return nil, errors.Errorf("unsupported type %s", t.Kind())
+	}
+}
+
+func StructValueToJen(structName string, s interface{}) (jen.Code, error) {
+	val := reflect.ValueOf(s)
+	typ := val.Type()
+
+	// Check if the input is a struct or a pointer to a struct
+	if typ.Kind() == reflect.Ptr {
+		val = val.Elem()
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil, errors.New("input is not a struct or a pointer to a struct")
+	}
+
+	var err error
+	// Start building the struct instantiation
+	ret := jen.Var().Id(structName).Op("=").StructFunc(func(g *jen.Group) {
+		for i := 0; i < val.NumField(); i++ {
+			fieldVal := val.Field(i)
+			fieldType := typ.Field(i)
+
+			v, err2 := LiteralToJen(fieldVal)
+			if err2 != nil {
+				err = err2
+				return
+			}
+			// Add the field and its value to the struct
+			g.Id(fieldType.Name).Op(":").Add(v)
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func LiteralToJen(v reflect.Value) (jen.Code, error) {
+	switch v.Kind() {
+	case reflect.String:
+		return jen.Lit(v.String()), nil
+	case reflect.Int:
+		return jen.Lit(int(v.Int())), nil
+	case reflect.Int8:
+		return jen.Lit(int8(v.Int())), nil
+	case reflect.Int16:
+		return jen.Lit(int16(v.Int())), nil
+	case reflect.Int32:
+		return jen.Lit(int32(v.Int())), nil
+	case reflect.Int64:
+		return jen.Lit(v.Int()), nil
+	case reflect.Uint:
+		return jen.Lit(uint(v.Uint())), nil
+	case reflect.Uint8:
+		return jen.Lit(uint8(v.Uint())), nil
+	case reflect.Uint16:
+		return jen.Lit(uint16(v.Uint())), nil
+	case reflect.Uint32:
+		return jen.Lit(uint32(v.Uint())), nil
+	case reflect.Uint64:
+		return jen.Lit(v.Uint()), nil
+	case reflect.Float32:
+		return jen.Lit(float32(v.Float())), nil
+	case reflect.Float64:
+		return jen.Lit(v.Float()), nil
+	case reflect.Bool:
+		return jen.Lit(v.Bool()), nil
+	case reflect.Interface:
+		return LiteralToJen(v.Elem())
+	case reflect.Slice, reflect.Array:
+		var err error
+		t, err := TypeToJen(v.Type())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert slice type to jen")
+		}
+		ret := jen.Add(t).ValuesFunc(func(g *jen.Group) {
+			for i := 0; i < v.Len(); i++ {
+				toJen, err_ := LiteralToJen(v.Index(i))
+				if err_ != nil {
+					err = err_
+					return
+				}
+				g.Add(toJen)
+			}
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		return ret, nil
+	case reflect.Map:
+		t, err := TypeToJen(v.Type().Key())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert map key type to jen")
+		}
+		v_, err := TypeToJen(v.Type().Elem())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert map value type to jen")
+		}
+		ret := jen.Map(t).Add(v_).
+			Values(jen.DictFunc(func(d jen.Dict) {
+				for _, key := range v.MapKeys() {
+					k, err_ := LiteralToJen(key)
+					if err_ != nil {
+						err = err_
+						return
+					}
+					v, err_ := LiteralToJen(v.MapIndex(key))
+					if err_ != nil {
+						err = err_
+						return
+					}
+					d[k] = v
+				}
+			}))
+		if err != nil {
+			return nil, err
+		}
+		return ret, nil
+	case reflect.Struct:
+		var err error
+		t := v.Type()
+		ret := jen.Id(t.Name())
+		if t.Name() == "" {
+			c, err := TypeToJen(t)
+			if err != nil {
+				return nil, err
+			}
+			ret = jen.Add(c)
+		}
+
+		ret = ret.ValuesFunc(func(g *jen.Group) {
+			for i := 0; i < v.NumField(); i++ {
+				fieldVal := v.Field(i)
+				fieldType := v.Type().Field(i)
+				toJen, err2 := LiteralToJen(fieldVal)
+				if err2 != nil {
+					err = err2
+					return
+				}
+				g.Id(fieldType.Name).Op(":").Add(toJen)
+			}
+		})
+		if err != nil {
+			return nil, err
+		}
+		return ret, nil
+	// pointer to struct
+	case reflect.Ptr:
+		// check if pointer to struct
+		if v.Elem().Kind() != reflect.Struct {
+			return nil, errors.Errorf("unsupported type %s", v.Kind())
+		}
+		v_, err := LiteralToJen(v.Elem())
+		if err != nil {
+			return nil, err
+		}
+		return jen.Op("&").Add(v_), nil
+	default:
+		// Default case for unsupported types
+		return nil, errors.Errorf("unsupported type %s", v.Kind())
+	}
+}

--- a/pkg/codegen/helpers_test.go
+++ b/pkg/codegen/helpers_test.go
@@ -1,0 +1,310 @@
+package codegen
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dave/jennifer/jen"
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper function to convert jen.Code to string for easy comparison
+// It's a bit oblique because you can't just render arbitrary jen.Code
+func codeToString(code jen.Code) string {
+	j := jen.NewFile("test")
+	j.NoFormat = true
+	j.Add(code)
+	ret := j.GoString()
+	return strings.TrimPrefix(ret, "package test\n\n\n")
+}
+
+func TestTypeToJen(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    reflect.Type
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "string type",
+			input:    reflect.TypeOf(""),
+			expected: "string",
+			wantErr:  false,
+		},
+		{
+			name:     "int type",
+			input:    reflect.TypeOf(0),
+			expected: "int",
+			wantErr:  false,
+		},
+		{
+			name:     "uint type",
+			input:    reflect.TypeOf(uint(0)),
+			expected: "uint",
+			wantErr:  false,
+		},
+		{
+			name:     "float32 type",
+			input:    reflect.TypeOf(float32(0)),
+			expected: "float64", // jen package might not differentiate between float32 and float64
+			wantErr:  false,
+		},
+		{
+			name:     "bool type",
+			input:    reflect.TypeOf(true),
+			expected: "bool",
+			wantErr:  false,
+		},
+		{
+			name:     "pointer to int",
+			input:    reflect.TypeOf(new(int)),
+			expected: "* int",
+			wantErr:  false,
+		},
+		{
+			name:     "slice of strings",
+			input:    reflect.TypeOf([]string{}),
+			expected: "[] string",
+			wantErr:  false,
+		},
+		{
+			name: "slice of slice of strings",
+			input: func() reflect.Type {
+				s := []string{}
+				return reflect.TypeOf([][]string{s})
+			}(),
+			expected: "[] [] string",
+			wantErr:  false,
+		},
+		{
+			name:     "map from string to int",
+			input:    reflect.TypeOf(map[string]int{}),
+			expected: "map[string] int",
+			wantErr:  false,
+		},
+		{
+			name: "interface{}",
+			input: func() reflect.Type {
+				s := map[string]interface{}{}
+				t := reflect.TypeOf(s)
+				return t.Elem()
+			}(),
+			expected: "interface{}",
+			wantErr:  false,
+		},
+		{
+			name:     "map from string to interface",
+			input:    reflect.TypeOf(map[string]interface{}{}),
+			expected: "map[string] interface{}",
+			wantErr:  false,
+		},
+		{
+			name: "map from string to slice of int",
+			input: func() reflect.Type {
+				s := []int{}
+				return reflect.TypeOf(map[string][]int{"": s})
+			}(),
+			expected: "map[string] [] int",
+			wantErr:  false,
+		},
+		{
+			name:     "struct type",
+			input:    reflect.TypeOf(struct{ Name string }{}),
+			expected: "struct{\nName string\n}",
+			wantErr:  false,
+		},
+		{
+			name: "struct type with pointer to struct",
+			input: func() reflect.Type {
+				type T struct {
+					Name string
+				}
+				return reflect.TypeOf(struct{ Name *T }{})
+			}(),
+			expected: "struct{\nName * struct{\nName string\n}\n}",
+			wantErr:  false,
+		},
+		// Error case example
+		{
+			name:     "unsupported type",
+			input:    reflect.TypeOf(make(chan int)),
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TypeToJen(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TypeToJen() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if got == nil {
+				panic("got nil jen.Code")
+			}
+			assert.Equal(t, tt.expected, codeToString(got))
+		})
+	}
+}
+
+type StructTest struct {
+	Name string
+}
+
+func TestLiteralToJen(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+		wantErr  bool
+	}{
+		{
+			"int",
+			1,
+			"1",
+			false,
+		},
+		{
+			"int32",
+			int32(1),
+			"int32(1)",
+			false,
+		},
+		{
+			"uint64",
+			uint64(1),
+			"uint64(0x1)",
+			false,
+		},
+		{
+			"float",
+			1.0,
+			"1.0",
+			false,
+		},
+		{
+			"float32",
+			float32(1.2),
+			"float32(1.2)",
+			false,
+		},
+		{
+			"string",
+			"1",
+			"\"1\"",
+			false,
+		},
+		{
+			name:     "bool type",
+			input:    true,
+			expected: "true",
+			wantErr:  false,
+		},
+		{
+			name:     "slice of strings",
+			input:    []string{},
+			expected: "[] string {}",
+			wantErr:  false,
+		},
+		{name: "slice of strings (1 value)",
+			input:    []string{"a"},
+			expected: "[] string {\"a\"}",
+			wantErr:  false,
+		},
+		{
+			name:     "slice of strings (3 values)",
+			input:    []string{"a", "b", "c"},
+			expected: "[] string {\"a\",\"b\",\"c\"}",
+			wantErr:  false,
+		},
+		{
+			name:     "slice of slice of strings",
+			input:    [][]string{{"a", "b", "c"}, {"d", "e", "f"}},
+			expected: "[] [] string {[] string {\"a\",\"b\",\"c\"},[] string {\"d\",\"e\",\"f\"}}",
+			wantErr:  false,
+		},
+		{
+			name:     "map from string to int (empty)",
+			input:    map[string]int{},
+			expected: "map[string] int {}",
+			wantErr:  false,
+		},
+		{
+			name:     "map from string to int (1 value)",
+			input:    map[string]int{"a": 1},
+			expected: "map[string] int {\"a\":1}",
+			wantErr:  false,
+		},
+		{
+			name:     "map from string to int (3 values)",
+			input:    map[string]int{"a": 1, "b": 2, "c": 3},
+			expected: "map[string] int {\n\"a\":1,\n\"b\":2,\n\"c\":3,\n}",
+			wantErr:  false,
+		},
+		{
+			name:     "interface{}",
+			input:    map[string]interface{}{},
+			expected: "map[string] interface{} {}",
+			wantErr:  false,
+		},
+		{
+			name:     "map from string to interface",
+			input:    map[string]interface{}{"a": 1, "b": "2", "c": true},
+			expected: "map[string] interface{} {\n\"a\":1,\n\"b\":\"2\",\n\"c\":true,\n}",
+			wantErr:  false,
+		},
+		{
+			name:     "map from string to slice of int",
+			input:    map[string][]int{"a": {1, 2, 3}, "b": {4, 5, 6}},
+			expected: "map[string] [] int {\n\"a\":[] int {1,2,3},\n\"b\":[] int {4,5,6},\n}",
+			wantErr:  false,
+		},
+		{
+			name: "struct type with name",
+			input: func() StructTest {
+				return StructTest{Name: "test"}
+			}(),
+			expected: "StructTest {Name : \"test\"}",
+		},
+		{
+			name:     "struct type",
+			input:    struct{ Name string }{Name: "test"},
+			expected: "struct{\nName string\n} {Name : \"test\"}",
+			wantErr:  false,
+		},
+		{
+			name:     "struct type with pointer to struct",
+			input:    struct{ Name *struct{ Name string } }{Name: &struct{ Name string }{Name: "test"}},
+			expected: "struct{\nName * struct{\nName string\n}\n} {Name : & struct{\nName string\n} {Name : \"test\"}}",
+			wantErr:  false,
+		},
+		// Error case example
+		{
+			name:    "unsupported type",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LiteralToJen(reflect.ValueOf(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LiteralToJen() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if got == nil {
+				panic("got nil jen.Code")
+			}
+			assert.Equal(t, tt.expected, codeToString(got))
+		})
+	}
+
+}


### PR DESCRIPTION
- Added a `codegen` command to `sqleton` CLI for generating Go code from YAML command definitions.
- The code generation is handled by the `SqlCommandCodeGenerator` struct in `codegen.go`:
  - `defineRunMethod` generates the `Run` method for the command struct.
  - `defineNewFunction` creates a constructor function for the command struct.
  - `defineConstants` declares constants for the command's main query and subqueries.
  - `defineStruct` and `defineParametersStruct` outline the command and parameter structs.
  - `GenerateCommandCode` orchestrates the code generation process.
- Auxiliary functions in `glazed.go` assist in the generation process:
  - `ParameterDefinitionToDict` converts parameter definitions to a dictionary format.
  - `FlagTypeToGoType` maps parameter types to Go types.
- Utility functions in `helpers.go` provide generic type and value conversions for code generation.
- The `codegen` command is registered within the application's main command set in `main.go`.