### PR TITLE
:ambulance: Fix glazed and parameter defaults in cobra commands

### DIFF
--- a/cmd/sqleton/cmds/db.go
+++ b/cmd/sqleton/cmds/db.go
@@ -35,10 +35,13 @@ func createConfigFromCobra(cmd *cobra.Command) *sql2.DatabaseConfig {
 	dbtLayer, err := sql2.NewDbtParameterLayer()
 	cobra.CheckErr(err)
 
-	description := cmds.NewCommandDescription(cmd.Name(),
-		cmds.WithLayersList(connectionLayer, dbtLayer))
+	description := cmds.NewCommandDescription(
+		cmd.Name(),
+		cmds.WithLayersList(connectionLayer, dbtLayer),
+	)
 
-	parser, err := cli.NewCobraParserFromCommandDescription(description,
+	parser, err := cli.NewCobraParserFromLayers(
+		description.Layers,
 		cli.WithCobraMiddlewaresFunc(sql2.GetCobraCommandSqletonMiddlewares),
 	)
 	cobra.CheckErr(err)


### PR DESCRIPTION
In general, loading layers from cobra directly now requires the full string of middlewares, so it's probably good going for a hunt through all the stacks of stuff I have.
