### PR TITLE
Bump sqleton and enable cgo support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,21 @@ permissions:
 
 
 jobs:
-  goreleaser:
-    runs-on: ubuntu-latest
+  release-linux:
+    runs-on: ubuntu-24.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Install cross-compilers
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            build-essential \
+            gcc-aarch64-linux-gnu \
+            gcc-x86-64-linux-gnu
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -36,7 +43,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.19.5'
+          go-version: '>=1.22.0'
           cache: true
 
       - name: Import GPG key
@@ -51,7 +58,41 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean 
+          args: release --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
+          TAP_GITHUB_TOKEN: ${{ secrets.RELEASE_ACTION_PAT }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+
+  release-darwin:
+    runs-on: macos-14
+    needs: release-linux
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22.0'
+          cache: true
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GO_GO_GOLEMS_SIGN_KEY }}
+          passphrase: ${{ secrets.GO_GO_GOLEMS_SIGN_PASSPHRASE }}
+          fingerprint: "6EBE1DF0BDF48A1BBA381B5B79983EF218C6ED7E"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,10 +9,12 @@ before:
     - go generate ./...
 builds:
   - env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     main: ./cmd/sqleton
     binary: sqleton
     id: sqleton-binaries
+    tags:
+      - sqlite_fts5
     goos:
       - linux
 # I am not able to test windows at the time
@@ -21,6 +23,17 @@ builds:
     goarch:
       - amd64
       - arm64
+    # overrides:
+    #   - goos: linux
+    #     goarch: amd64
+        # env:
+        #   - CC=x86_64-linux-gnu-gcc
+        #   - CXX=x86_64-linux-gnu-g++
+      # - goos: linux
+      #   goarch: arm64
+        # env:
+        #   - CC=aarch64-linux-gnu-gcc
+        #   - CXX=aarch64-linux-gnu-g++
 
 # Add this section to include raw binaries
 archives:

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ test:
 
 build:
 	go generate ./...
-	go build $(LDFLAGS) ./...
+	go build -tags sqlite_fts5 $(LDFLAGS) ./...
 
 sqleton:
-	go build $(LDFLAGS) -o sqleton ./cmd/sqleton
+	go build -tags sqlite_fts5 $(LDFLAGS) -o sqleton ./cmd/sqleton
 
 build-docker: sqleton
 #	GOOS=linux GOARCH=amd64 go build -o sqleton ./cmd/sqleton
@@ -78,7 +78,7 @@ bump-glazed:
 
 SQLETON_BINARY=$(shell which sqleton)
 install:
-	go build $(LDFLAGS) -o ./dist/sqleton ./cmd/sqleton && \
+	go build -tags sqlite_fts5 $(LDFLAGS) -o ./dist/sqleton ./cmd/sqleton && \
 		cp ./dist/sqleton $(SQLETON_BINARY)
 
 # Path to CodeQL CLI - adjust based on installation location

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ tag-patch:
 	git tag $(shell svu patch)
 
 release:
-	git push --tags
+	git push origin --tags
 	GOPROXY=proxy.golang.org go list -m github.com/go-go-golems/sqleton@$(shell svu current)
 
 bump-glazed:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/dave/jennifer v1.7.0
-	github.com/go-go-golems/clay v0.1.45
+	github.com/go-go-golems/clay v0.1.47
 	github.com/go-go-golems/glazed v0.6.10
 	github.com/go-go-golems/parka v0.5.28
 	github.com/go-sql-driver/mysql v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/go-go-golems/clay v0.1.45 h1:fctmNW9REp8tSxZCXDsmOJIxtMXCI2315EYCmSOyIx4=
-github.com/go-go-golems/clay v0.1.45/go.mod h1:ZLOqwSa6tUIV9gSTDx97rNbMeqUQUHq+2I3HVT2Urx0=
+github.com/go-go-golems/clay v0.1.47 h1:z0ls5mGJ+/Sz66F1lgTtA7h7V9dfgi2+KIqscDNkKB0=
+github.com/go-go-golems/clay v0.1.47/go.mod h1:ZLOqwSa6tUIV9gSTDx97rNbMeqUQUHq+2I3HVT2Urx0=
 github.com/go-go-golems/glazed v0.6.10 h1:MMngatV5zT2vzPBYW1mtiVg3Sboh5/V4DqR11nGLjQ0=
 github.com/go-go-golems/glazed v0.6.10/go.mod h1:xJZ2H2NUlJk02le1+ypHE0/LvAH0EW7NrPFkpD/7/6o=
 github.com/go-go-golems/parka v0.5.28 h1:A5VQK6XqPrREL9GL5bvqCqYZhpuaE771X91DeNtLxiM=


### PR DESCRIPTION
- Update sqleton dependency to version 0.1.47
- Change CGO_ENABLED from 0 to 1 to enable cgo support
- Update GitHub Actions workflow to use Ubuntu 24.04
- Install necessary cross-compilers in the CI environment
- Modify build commands to include `-tags sqlite_fts5`
- Add GPG key import for signing releases in the CI workflow
- Adjust release steps for better cross-platform support