### PR TITLE
fix(build): remove old marcboeker/go-duckdb import to resolve linker collisions

### DIFF
--- a/cmd/sqleton/cmds/db.go
+++ b/cmd/sqleton/cmds/db.go
@@ -16,8 +16,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/spf13/cobra"
 
-	_ "github.com/go-sql-driver/mysql"  // MySQL driver for database/sql
-	_ "github.com/marcboeker/go-duckdb" // DuckDB driver for database/sql
+	_ "github.com/go-sql-driver/mysql" // MySQL driver for database/sql
 )
 
 // From chatGPT:

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/huandu/go-sqlbuilder v1.36.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/jmoiron/sqlx v1.4.0
-	github.com/marcboeker/go-duckdb v1.8.5
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.7.0
@@ -134,6 +133,7 @@ require (
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/marcboeker/go-duckdb v1.8.5 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/README.md
+++ b/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/README.md
@@ -1,0 +1,21 @@
+# Fix sqleton compile: duplicate DuckDB static library linker errors
+
+This is the document workspace for ticket FIX-SQLETON-DUCKDB-LINK.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket FIX-SQLETON-DUCKDB-LINK --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket FIX-SQLETON-DUCKDB-LINK --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket FIX-SQLETON-DUCKDB-LINK --field Status --value review`

--- a/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/changelog.md
+++ b/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/changelog.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2026-05-02
+
+- Initial workspace created
+
+
+## 2026-05-02
+
+Diagnosed and fixed duplicate DuckDB static library linker errors by removing old driver import from cmd/sqleton/cmds/db.go and running go mod tidy
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/sqleton/cmd/sqleton/cmds/db.go — removed _ github.com/marcboeker/go-duckdb import
+- /home/manuel/code/wesen/corporate-headquarters/sqleton/go.mod — go mod tidy removed direct dependency on marcboeker/go-duckdb
+

--- a/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/design-doc/01-sqleton-duckdb-linker-conflict-deep-dive-and-fix-guide-for-new-interns.md
+++ b/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/design-doc/01-sqleton-duckdb-linker-conflict-deep-dive-and-fix-guide-for-new-interns.md
@@ -1,0 +1,393 @@
+---
+Title: ""
+Ticket: ""
+Status: ""
+Topics: []
+DocType: ""
+Intent: ""
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../clay/pkg/sql/config.go
+      Note: clay file importing the new driver
+    - Path: ../../../../../../../go.work
+      Note: workspace file causing local clay resolution
+    - Path: cmd/sqleton/cmds/db.go
+      Note: source file that contained the old driver import
+    - Path: go.mod
+      Note: module manifest showing dependency change
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Sqleton DuckDB Linker Conflict: Deep Dive and Fix Guide for New Interns
+
+## 1. Executive Summary
+
+**Sqleton** is our Go CLI tool for running SQL queries against multiple database backends (MySQL, PostgreSQL, SQLite, DuckDB). Recently, running `make build` in the sqleton repository started failing with hundreds of linker errors of the form `multiple definition of 'duckdb_*'`. This document explains, from first principles, why this happened and how we fixed it. If you are a new intern, read this to understand our Go monorepo workspace, how Cgo-based database drivers work, and how to diagnose dependency diamond problems.
+
+**The fix in one sentence:** Remove the direct import of the old DuckDB driver (`github.com/marcboeker/go-duckdb`) from sqleton's source code, because our shared `clay` library had already migrated to the new official driver (`github.com/duckdb/duckdb-go/v2`), and linking two different static DuckDB libraries simultaneously causes symbol collisions.
+
+---
+
+## 2. What is Sqleton?
+
+Sqleton (`github.com/go-go-golems/sqleton`) is a command-line SQL runner built on top of our internal frameworks:
+
+- **Glazed** (`go-go-golems/glazed`) — provides structured command parsing, parameter layers, row processing, and output formatting (JSON, YAML, tables).
+- **Clay** (`go-go-golems/clay`) — provides shared utilities, especially database connection management (`clay/pkg/sql`).
+- **Parka** (`go-go-golems/parka`) — optional web/REST frontend layer.
+
+Sqleton itself is relatively thin: it defines Cobra CLI commands, reads SQL query definitions from YAML files, and executes them through Go's standard `database/sql` interface. The actual heavy lifting (parsing connection strings, managing connection pools, formatting results) is delegated to Glazed and Clay.
+
+### 2.1 Key files in sqleton
+
+| File | Purpose |
+|------|---------|
+| `cmd/sqleton/main.go` | Entry point. Bootstraps Cobra, loads commands, starts the CLI. |
+| `cmd/sqleton/cmds/db.go` | Database management subcommands (`db test`, `db ls`, `db print-env`, etc.). This is where database drivers are imported as blank imports for side-effect registration. |
+| `pkg/cmds/*.go` | Core command definitions, SQL parameter parsing, query execution. |
+| `go.mod` | Go module manifest. Declares direct and transitive dependencies. |
+| `Makefile` | Build automation. Runs `go generate` and `go build -tags sqlite_fts5`. |
+
+---
+
+## 3. The Go Workspace: Why `../clay` Matters
+
+Our organization maintains multiple Go modules in a single Git repository (a **monorepo**). The directory structure looks like this:
+
+```
+corporate-headquarters/
+├── clay/          # github.com/go-go-golems/clay
+├── glazed/        # github.com/go-go-golems/glazed
+├── parka/         # github.com/go-go-golems/parka
+├── sqleton/       # github.com/go-go-golems/sqleton
+└── go.work        # Go workspace file
+```
+
+### 3.1 What is a Go workspace?
+
+A Go workspace (file: `go.work`) tells the Go toolchain: "When you are inside this directory tree, resolve module imports from these local directories instead of downloading them from the internet."
+
+Our workspace file contains:
+
+```go
+// corporate-headquarters/go.work
+go 1.26.2
+
+use (
+    ./clay
+    ./glazed
+    ./parka
+    ./sqleton
+    // ... many others
+)
+```
+
+**Consequence:** Even though sqleton's `go.mod` declares `require github.com/go-go-golems/clay v0.4.3`, the Go compiler actually uses the code in `../clay/` because the workspace says so. This is critical for day-to-day development: we can change Clay, Glazed, and Sqleton in lockstep without publishing new versions.
+
+**The trap:** Because the workspace silently redirects module resolution, a change in `../clay` can break `../sqleton` even if sqleton's `go.mod` has not changed. That is exactly what happened here.
+
+---
+
+## 4. What is DuckDB and Why Do We Use It?
+
+**DuckDB** is an in-process analytical database (similar to SQLite but optimized for OLAP workloads). It is written in C++. We use it because:
+
+- It can query CSV, Parquet, and JSON files directly with SQL.
+- It is embedded — no separate server process.
+- It has excellent performance for analytical queries.
+
+### 4.1 How Go talks to DuckDB
+
+Go cannot directly call C++ code. The bridge is built via **Cgo** and the **DuckDB C API**:
+
+```
++----------------------------------+
+|  Your Go code (sqleton)          |
+|  import "database/sql"           |
++----------------------------------+
+           |
+           v
++----------------------------------+
+|  Go database/sql driver          |
+|  (github.com/duckdb/duckdb-go/v2)|
++----------------------------------+
+           |
+           v (Cgo calls)
++----------------------------------+
+|  DuckDB C API (libduckdb)        |
+|  (C header + static library)     |
++----------------------------------+
+           |
+           v
++----------------------------------+
+|  DuckDB engine (C++)             |
+|  (inside libduckdb_static.a)     |
++----------------------------------+
+```
+
+The Go driver package contains C header files and a pre-compiled **static library** (`.a` file) for each platform:
+- `lib/linux-amd64/libduckdb_static.a` on Linux
+- `lib/darwin-arm64/libduckdb_static.a` on macOS
+
+When Go builds a binary that imports the driver, the Go linker (`ld`) embeds this static library into the final executable. This is why DuckDB-enabled Go binaries are large (~100+ MB) — they contain the entire database engine.
+
+---
+
+## 5. The Compile Error: Exactly What Happened
+
+Running `make build` produced a wall of text ending with:
+
+```
+/usr/bin/ld: /home/manuel/go/pkg/mod/github.com/duckdb/duckdb-go-bindings/lib/linux-amd64@v0.10501.0/libduckdb_static.a(ub_duckdb_main_capi.cpp.o): in function `duckdb::CAPIAggregateDestructor(...)':
+multiple definition of `duckdb::CAPIAggregateDestructor(...)'; 
+/home/manuel/go/pkg/mod/github.com/marcboeker/go-duckdb@v1.8.5/deps/linux_amd64/libduckdb.a(ub_duckdb_main_capi.cpp.o): first defined here
+
+/usr/bin/ld: ... multiple definition of `duckdb_appender_create'; ...
+/usr/bin/ld: ... multiple definition of `duckdb_append_bool'; ...
+# (hundreds more lines like this)
+```
+
+The key observation: the linker is complaining about **two different files**:
+
+1. `marcboeker/go-duckdb@v1.8.5/deps/linux_amd64/libduckdb.a` — the **old** driver
+2. `duckdb/duckdb-go-bindings/lib/linux-amd64@v0.10501.0/libduckdb_static.a` — the **new** driver
+
+Both are DuckDB static libraries, both define the same C symbols (like `duckdb_appender_create`), and the linker refuses to link both into one binary.
+
+---
+
+## 6. Root Cause Analysis: The Dependency Diamond
+
+### 6.1 The two DuckDB drivers
+
+| Package | Author | Status | DuckDB Version |
+|---------|--------|--------|----------------|
+| `github.com/marcboeker/go-duckdb` | Community (Marc Boeker) | Legacy / Old | v1.8.x |
+| `github.com/duckdb/duckdb-go/v2` | Official DuckDB Labs | Current | v2.105.x |
+
+The DuckDB organization recently released an official Go driver. Our `clay` library migrated to the official driver. Sqleton did not.
+
+### 6.2 The dependency graph
+
+Because of the Go workspace, the actual resolved graph looks like this:
+
+```
+                    sqleton binary
+                         |
+         +---------------+---------------+
+         |                               |
+         v                               v
+   sqleton/cmd/db.go              clay/pkg/sql
+   (local source)                 (from ../clay/)
+         |                               |
+   _ "marcboeker/go-duckdb"      _ "duckdb/duckdb-go/v2"
+         |                               |
+         v                               v
+   libduckdb.a                  libduckdb_static.a
+   (old static lib)             (new static lib)
+   same C symbols!              same C symbols!
+         \                               /
+          \______________+______________/
+                         |
+                    LINKER SAYS NO
+                    "multiple definition"
+```
+
+### 6.3 Why did this work before?
+
+Before the clay migration, both sqleton and clay imported `marcboeker/go-duckdb`. There was only one static library, so the linker was happy. When clay was upgraded to the official driver, the workspace caused sqleton to pick up the new clay code, but sqleton still imported the old driver. Two libraries entered the link step; the linker rejected them.
+
+### 6.4 Why is this a "diamond dependency"?
+
+A diamond dependency occurs when two of your dependencies each depend on a different version of the same underlying library. In Go, this is usually fine because Go's module graph selects a single version (Minimal Version Selection). **But** when the "library" is a C static library embedded inside a Go package, Go's version selection cannot merge two different `.a` files. The linker sees both and fails.
+
+---
+
+## 7. How We Diagnosed It
+
+Here is the exact debugging process, step by step, so you can reproduce it on similar issues.
+
+### 7.1 Step 1: Read the error carefully
+
+Look at the file paths in the linker output. We saw two distinct module cache paths:
+- `marcboeker/go-duckdb@v1.8.5/...`
+- `duckdb/duckdb-go-bindings/lib/linux-amd64@v0.10501.0/...`
+
+This immediately tells us two different packages are pulling in two different DuckDB libraries.
+
+### 7.2 Step 2: Find who imports each package
+
+```bash
+# Which package needs the NEW driver?
+go mod why github.com/duckdb/duckdb-go/v2
+# Output:
+# github.com/go-go-golems/clay/pkg/sql
+# github.com/duckdb/duckdb-go/v2
+
+# Which package needs the OLD driver?
+go mod why github.com/marcboeker/go-duckdb
+# Output:
+# github.com/go-go-golems/sqleton/cmd/sqleton/cmds
+# github.com/marcboeker/go-duckdb
+```
+
+### 7.3 Step 3: Find the import in source code
+
+```bash
+rg -n "marcboeker/go-duckdb" cmd/ pkg/ --type go
+# Output:
+# cmd/sqleton/cmds/db.go:20:    _ "github.com/marcboeker/go-duckdb"
+```
+
+### 7.4 Step 4: Check the workspace
+
+```bash
+go env GOWORK
+# Output: /home/manuel/code/wesen/corporate-headquarters/go.work
+
+cat /home/manuel/code/wesen/corporate-headquarters/go.work | grep clay
+# Output: ./clay
+```
+
+This confirms that sqleton is using the local `../clay` (which has the new driver) rather than the tagged v0.4.3 from the module cache (which still had the old driver).
+
+### 7.5 Step 5: Verify the driver registration in clay
+
+```bash
+cat ../clay/pkg/sql/config.go | grep "duckdb-go/v2"
+# Output:
+# _ "github.com/duckdb/duckdb-go/v2"
+```
+
+Clay already imports the new driver as a blank import, which means `database/sql` will already have the `"duckdb"` driver registered whenever `clay/pkg/sql` is imported. Sqleton does not need to import any DuckDB driver itself.
+
+---
+
+## 8. The Fix
+
+### 8.1 Code change
+
+File: `cmd/sqleton/cmds/db.go`
+
+**Before:**
+```go
+import (
+    // ... other imports ...
+    _ "github.com/go-sql-driver/mysql"  // MySQL driver for database/sql
+    _ "github.com/marcboeker/go-duckdb" // DuckDB driver for database/sql
+)
+```
+
+**After:**
+```go
+import (
+    // ... other imports ...
+    _ "github.com/go-sql-driver/mysql" // MySQL driver for database/sql
+    // NOTE: DuckDB driver is imported transitively via clay/pkg/sql
+)
+```
+
+We simply removed the blank import of `github.com/marcboeker/go-duckdb`.
+
+### 8.2 Module cleanup
+
+After removing the import, run:
+
+```bash
+go mod tidy
+```
+
+This updates `go.mod` and `go.sum` to remove the now-unused direct dependency on `marcboeker/go-duckdb`. It may still appear as an **indirect** dependency if some other transitive dependency uses it, but it will no longer be compiled into the sqleton binary.
+
+### 8.3 Verify the build
+
+```bash
+make build
+```
+
+Expected output:
+```
+go generate ./...
+go build -tags sqlite_fts5 -ldflags "-X main.version=v0.4.3-2a40fc2-dirty" ./...
+```
+
+No linker errors. Success.
+
+---
+
+## 9. Why the Fix Works
+
+When we removed the old import, the Go compiler no longer included the old static library (`libduckdb.a` from `marcboeker/go-duckdb`) in the link step. Only the new static library (`libduckdb_static.a` from `duckdb-go-bindings`) remains. All DuckDB C symbols now have exactly one definition, and the linker succeeds.
+
+Because `clay/pkg/sql` (which sqleton already imports) includes `_ "github.com/duckdb/duckdb-go/v2"`, the `database/sql` driver named `"duckdb"` is still registered at program startup. Sqleton can still open DuckDB connections via `sql.Open("duckdb", dsn)` without any code changes elsewhere.
+
+---
+
+## 10. Prevention: How to Avoid This in the Future
+
+### 10.1 When upgrading shared libraries, audit all workspace members
+
+If you upgrade a Cgo-based dependency in `clay`, `glazed`, or `parka`, check every module in the workspace (`go.work`) that depends on it. Look for:
+
+- Direct imports of the old package.
+- `go.mod` lines that pin the old package as a direct dependency.
+
+Use this command to scan:
+
+```bash
+# In the monorepo root
+for dir in clay glazed parka sqleton escuse-me; do
+  echo "=== $dir ==="
+  (cd $dir && rg -l "marcboeker/go-duckdb" --type go 2>/dev/null)
+done
+```
+
+### 10.2 Prefer transitive driver registration
+
+If a shared library (`clay/pkg/sql`) already registers a database driver, application code (`sqleton`) should not import the driver again. This is a standard Go pattern: the lowest-level shared package registers the driver; higher-level packages just use `database/sql`.
+
+### 10.3 After any `go.mod` change in a workspace member, build siblings
+
+Our CI should ideally build all workspace members when any shared dependency changes. Locally, you can run:
+
+```bash
+# From monorepo root
+for dir in sqleton escuse-me parka; do
+  (cd $dir && make build)
+done
+```
+
+### 10.4 Understand when `go mod tidy` is not enough
+
+`go mod tidy` fixes module metadata, but it cannot fix **source-level import mismatches**. If two of your imports each embed a different C static library with the same symbols, `go mod tidy` will happily keep both in `go.mod`. You must fix the imports in `.go` source files.
+
+---
+
+## 11. Concepts Glossary for New Interns
+
+| Term | Definition |
+|------|------------|
+| **Cgo** | Go's FFI (Foreign Function Interface) that lets Go code call C code. Used by database drivers that wrap C/C++ libraries. |
+| **Static library** | A `.a` file (Unix) or `.lib` file (Windows) containing compiled object code. Linked directly into the final executable. |
+| **Linker** | The tool (usually `ld` on Linux) that combines compiled object files and libraries into a single executable. It errors if the same symbol is defined twice. |
+| **Blank import** | `import _ "package"` — imports a package only for its side effects (typically `init()` functions, such as driver registration). |
+| **Go workspace** | A `go.work` file that groups multiple Go modules so they resolve each other locally instead of from the module proxy. |
+| **MVS** | Minimal Version Selection — Go's algorithm for picking dependency versions. It does not help with C library collisions. |
+| **Driver registration** | In Go's `database/sql`, drivers call `sql.Register("name", driverInstance)` in their `init()` so `sql.Open("name", ...)` works. |
+
+---
+
+## 12. References
+
+- **Sqleton source file changed:** `cmd/sqleton/cmds/db.go`
+- **Sqleton module manifest:** `go.mod`
+- **Monorepo workspace:** `/home/manuel/code/wesen/corporate-headquarters/go.work`
+- **Clay SQL package (new driver):** `../clay/pkg/sql/config.go`
+- **New official DuckDB Go driver:** `github.com/duckdb/duckdb-go/v2` (resolved in module cache at `~/go/pkg/mod/github.com/duckdb/duckdb-go/v2@v2.10501.0`)
+- **Old community DuckDB Go driver:** `github.com/marcboeker/go-duckdb` (resolved in module cache at `~/go/pkg/mod/github.com/marcboeker/go-duckdb@v1.8.5`)
+- **DuckDB C API docs:** https://duckdb.org/docs/api/c/overview

--- a/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/index.md
+++ b/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/index.md
@@ -1,0 +1,58 @@
+---
+Title: 'Fix sqleton compile: duplicate DuckDB static library linker errors'
+Ticket: FIX-SQLETON-DUCKDB-LINK
+Status: active
+Topics:
+    - build
+    - go
+    - duckdb
+    - linker
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-02T10:38:03.200925529-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Fix sqleton compile: duplicate DuckDB static library linker errors
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- build
+- go
+- duckdb
+- linker
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/reference/01-investigation-diary-duckdb-duplicate-symbol-linker-failure.md
+++ b/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/reference/01-investigation-diary-duckdb-duplicate-symbol-linker-failure.md
@@ -1,0 +1,171 @@
+---
+Title: ""
+Ticket: ""
+Status: ""
+Topics: []
+DocType: ""
+Intent: ""
+Owners: []
+RelatedFiles:
+    - Path: cmd/sqleton/cmds/db.go
+      Note: removed old driver import
+    - Path: go.mod
+      Note: dependency cleanup after go mod tidy
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Investigation Diary: DuckDB Duplicate Symbol Linker Failure
+
+## 2026-05-02 — Initial Report and Reproduction
+
+**Reported:** Sqleton fails to compile. User suspects a prior fix in `../clay` (avoiding linking a different DuckDB version) did not fully resolve the issue.
+
+**Reproduction command:**
+```bash
+make build
+```
+
+**Observed output (truncated):**
+```
+go generate ./...
+go build -tags sqlite_fts5 -ldflags "-X main.version=v0.4.3-2a40fc2-" ./...
+# github.com/go-go-golems/sqleton/cmd/sqleton
+.../link: running gcc failed: exit status 1
+/usr/bin/ld: .../libduckdb_static.a(ub_duckdb_main_capi.cpp.o): in function `duckdb::CAPIAggregateDestructor(...)':
+multiple definition of `duckdb::CAPIAggregateDestructor(...)'; .../libduckdb.a(ub_duckdb_main_capi.cpp.o): first defined here
+# (hundreds of similar lines)
+```
+
+**Initial hypothesis:** Two DuckDB libraries are being linked simultaneously.
+
+---
+
+## 2026-05-02 — Dependency Graph Analysis
+
+Ran `go mod graph | grep -i duckdb` to see which modules depend on which DuckDB packages.
+
+**Key findings:**
+- `github.com/go-go-golems/sqleton` directly requires `github.com/marcboeker/go-duckdb v1.8.5`
+- `github.com/go-go-golems/clay` (local workspace replacement) requires `github.com/duckdb/duckdb-go/v2 v2.10501.0`
+- Both the old and new drivers embed their own static C libraries (`libduckdb.a` vs `libduckdb_static.a`)
+
+**Command:**
+```bash
+go mod why github.com/duckdb/duckdb-go/v2
+# github.com/go-go-golems/clay/pkg/sql
+# github.com/duckdb/duckdb-go/v2
+
+go mod why github.com/marcboeker/go-duckdb
+# github.com/go-go-golems/sqleton/cmd/sqleton/cmds
+# github.com/marcboeker/go-duckdb
+```
+
+**Confirmed:** The old driver is pulled in by sqleton's own code; the new driver is pulled in by clay.
+
+---
+
+## 2026-05-02 — Source Code Inspection
+
+**File:** `cmd/sqleton/cmds/db.go`
+
+Found the offending blank import:
+```go
+_ "github.com/marcboeker/go-duckdb" // DuckDB driver for database/sql
+```
+
+**File:** `../clay/pkg/sql/config.go`
+
+Found that clay already imports the new driver:
+```go
+_ "github.com/duckdb/duckdb-go/v2"
+```
+
+Since `db.go` imports `sql2 "github.com/go-go-golems/clay/pkg/sql"`, the new driver is already transitively included. The old import is redundant and harmful.
+
+---
+
+## 2026-05-02 — Workspace Confirmation
+
+**Command:**
+```bash
+go env GOWORK
+# /home/manuel/code/wesen/corporate-headquarters/go.work
+```
+
+This explains why sqleton picks up the migrated clay code even though sqleton's `go.mod` still pins `clay v0.4.3` (which used the old driver). The workspace overrides version resolution.
+
+---
+
+## 2026-05-02 — Fix Applied
+
+**Change:** Removed the old blank import from `cmd/sqleton/cmds/db.go`.
+
+**Diff:**
+```diff
+- 	_ "github.com/go-sql-driver/mysql"  // MySQL driver for database/sql
+- 	_ "github.com/marcboeker/go-duckdb" // DuckDB driver for database/sql
++ 	_ "github.com/go-sql-driver/mysql" // MySQL driver for database/sql
+```
+
+**Module cleanup:**
+```bash
+go mod tidy
+```
+
+This moved `marcboeker/go-duckdb` from `require` (direct) to an indirect dependency, but more importantly it is no longer compiled into the binary because nothing in the build graph imports it anymore.
+
+---
+
+## 2026-05-02 — Verification
+
+**Command:**
+```bash
+make build
+```
+
+**Result:**
+```
+go generate ./...
+go build -tags sqlite_fts5 -ldflags "-X main.version=v0.4.3-2a40fc2-dirty" ./...
+```
+
+Build completed successfully. No linker errors.
+
+---
+
+## What Worked
+
+- Using `go mod why` to trace dependency paths quickly identified the two sources of DuckDB.
+- Using `rg` to find the exact import line in source code made the fix obvious.
+- Checking `go env GOWORK` confirmed the workspace hypothesis.
+- Removing a single blank import and running `go mod tidy` was sufficient.
+
+## What Did Not Work
+
+- `go mod tidy` alone would not have fixed this because the problem was a source-level import, not a stale `go.mod` entry.
+- Upgrading `clay` in isolation without checking sibling workspace modules left sqleton in a broken state.
+
+## What Was Tricky
+
+- The error output is enormous (hundreds of "multiple definition" lines from `ld`), which can be intimidating. The trick is to scroll to the top and read the file paths in the linker command — they reveal which two libraries are colliding.
+- The `go.mod` of sqleton still lists `clay v0.4.3`, which uses the old driver. Without knowing about the workspace override, one might incorrectly conclude that clay is not the source of the new driver.
+
+## Code Review Instructions
+
+When reviewing this fix:
+
+1. Verify `cmd/sqleton/cmds/db.go` no longer imports `marcboeker/go-duckdb`.
+2. Verify `go.mod` no longer lists `marcboeker/go-duckdb` in the direct `require` block.
+3. Run `make build` locally and confirm a clean build.
+4. Optional: Run `go list -m all | grep duckdb` and confirm only `duckdb/duckdb-go/v2` and its bindings remain in the active module list.
+
+## Unresolved / Follow-up
+
+- **CI gap:** We do not have automated workspace-wide builds. A change in `clay` can break `sqleton`, `escuse-me`, or other dependents without anyone noticing until they run `make build` locally.
+- **Future driver upgrades:** When `duckdb-go/v2` releases a new version, we should upgrade it in `clay` first, then verify all workspace members.
+- **Documentation:** This ticket now serves as the canonical reference for diagnosing C static library collisions in our Go workspace.

--- a/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/reference/02-diary.md
+++ b/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/reference/02-diary.md
@@ -1,0 +1,150 @@
+---
+Title: ""
+Ticket: ""
+Status: ""
+Topics: []
+DocType: ""
+Intent: ""
+Owners: []
+RelatedFiles:
+    - Path: cmd/sqleton/cmds/db.go
+      Note: removed old driver import
+    - Path: go.mod
+      Note: dependency cleanup after go mod tidy
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Diary
+
+## Goal
+
+Capture the step-by-step investigation and fix for the sqleton compile failure caused by duplicate DuckDB static library symbols, and document the creation of the detailed intern guide and ticket deliverables.
+
+---
+
+## Step 1: Reproduce the Compile Error and Identify the Root Cause
+
+The user reported that `make build` in sqleton was failing with linker errors despite a recent fix in `../clay` to avoid linking a different DuckDB version. I started by running `make build` to see the exact failure, then traced the dependency graph to understand why two DuckDB libraries were being linked simultaneously.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new docmgr ticket to fix the compile issue of sqleton. Run make build and inspect the error that is happening, we recently fixed ../clay) to avoid linking a different duckdb version, but this seems to maybe not have fixed the issue? Create a detailed analysis / design / implementation guide that is very detailed for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet points and pseudocode and diagrams and api references and file references. It should be very clear and detailed. Store in the ticket and then upload to remarkable."
+
+**Assistant interpretation:** Create a docmgr ticket for the sqleton compile issue, diagnose the build failure, produce a comprehensive educational document for a new intern explaining the architecture and fix, store it in docmgr, and upload the bundle to reMarkable.
+
+**Inferred user intent:** The user wants both the immediate technical fix and a durable knowledge artifact that teaches future team members how Go workspaces, Cgo database drivers, and static library linking interact.
+
+### What I did
+- Ran `make build` in `/home/manuel/code/wesen/corporate-headquarters/sqleton`.
+- Captured the linker output showing `multiple definition of` errors for DuckDB C API symbols.
+- Ran `go mod graph | grep -i duckdb` to discover that both `github.com/marcboeker/go-duckdb` (old) and `github.com/duckdb/duckdb-go/v2` (new) were present in the module graph.
+- Ran `go mod why` for both packages to identify their consumers:
+  - `marcboeker/go-duckdb` was imported by `sqleton/cmd/sqleton/cmds`.
+  - `duckdb/duckdb-go/v2` was imported by `clay/pkg/sql`.
+- Used `rg` to find the exact source import: `cmd/sqleton/cmds/db.go` line 20.
+- Checked `go env GOWORK` and read `../go.work` to confirm the workspace override causing sqleton to resolve clay from `../clay` (already migrated) instead of the tagged v0.4.3.
+
+### Why
+- The compile error was a linker-level symbol collision, not a Go compilation error, which meant two C static libraries with identical symbols were being linked into the same binary.
+- Understanding the workspace was essential because sqleton's `go.mod` still declared `clay v0.4.3`, which used the old driver, but the local `../clay` had already migrated to the new driver.
+
+### What worked
+- `go mod why` immediately pointed to the two importing packages.
+- `rg` found the single line in Go source causing the old library to be pulled in.
+- Confirming the workspace explained the version mismatch.
+
+### What didn't work
+- Nothing failed during diagnosis; the investigation was straightforward once the workspace behavior was confirmed.
+
+### What I learned
+- The `go.work` file at the monorepo root silently redirects module resolution for all workspace members. This means `go.mod` version pins can be misleading when diagnosing dependency issues inside a workspace.
+- DuckDB's Go driver ecosystem recently split: the community driver (`marcboeker/go-duckdb`) is now legacy, and DuckDB Labs released an official driver (`duckdb/duckdb-go/v2`). Both embed platform-specific static `.a` libraries, making them fundamentally incompatible in the same binary.
+
+### What was tricky to build
+- The linker output is extremely verbose (hundreds of lines). The trick is to ignore the bulk of the errors and look at the first few lines, which name the two colliding archive files (`libduckdb.a` vs `libduckdb_static.a`). From there, the module paths in the file names reveal the two Go packages causing the collision.
+
+### What warrants a second pair of eyes
+- The fix is minimal (removing one blank import), but the underlying pattern (workspace + Cgo static libraries) is a systemic risk. Any future upgrade of a Cgo-based shared library in `clay` could break other workspace members in the same way.
+
+### What should be done in the future
+- Add workspace-wide CI builds so that a change in `clay` triggers builds of `sqleton`, `escuse-me`, `parka`, etc.
+- Create a runbook for upgrading Cgo-based dependencies across the monorepo.
+
+### Code review instructions
+- Review `cmd/sqleton/cmds/db.go`: the old import is removed, the MySQL import remains.
+- Review `go.mod`: `marcboeker/go-duckdb` should no longer be in the direct `require` block.
+- Validate: `make build` should complete without linker errors.
+
+### Technical details
+- **Error signature:** `multiple definition of 'duckdb::CAPIAggregateDestructor(...)'` (and hundreds of similar DuckDB C API symbols).
+- **Colliding libraries:**
+  - `~/go/pkg/mod/github.com/marcboeker/go-duckdb@v1.8.5/deps/linux_amd64/libduckdb.a`
+  - `~/go/pkg/mod/github.com/duckdb/duckdb-go-bindings/lib/linux-amd64@v0.10501.0/libduckdb_static.a`
+- **Fix commit:** The change removes `_ "github.com/marcboeker/go-duckdb"` from `cmd/sqleton/cmds/db.go` and runs `go mod tidy`.
+
+---
+
+## Step 2: Apply the Code Fix and Verify the Build
+
+After identifying the redundant old driver import, I removed it from `db.go`, ran `go mod tidy` to clean up `go.mod`, and rebuilt sqleton to confirm the linker errors were resolved.
+
+### What I did
+- Edited `cmd/sqleton/cmds/db.go` to remove the blank import of `github.com/marcboeker/go-duckdb`.
+- Ran `go mod tidy` to update module metadata.
+- Ran `make build` to verify the binary compiles successfully.
+
+### What worked
+- Build completed cleanly on the first try after removing the import.
+- `go mod tidy` correctly downgraded `marcboeker/go-duckdb` from a direct dependency to an indirect one (and it would eventually disappear entirely from the resolved build graph if no other dependency needed it).
+
+### What didn't work
+- N/A.
+
+### What was tricky to build
+- N/A; the fix was a single-line deletion.
+
+### Code review instructions
+- Files to review: `cmd/sqleton/cmds/db.go`, `go.mod`.
+- Validation command: `make build` from the sqleton repository root.
+
+---
+
+## Step 3: Create the Docmgr Ticket and Write the Intern Guide
+
+With the build fixed, I shifted to creating the durable knowledge artifact the user requested. I created a docmgr ticket (`FIX-SQLETON-DUCKDB-LINK`), added a design document for the intern guide, added an investigation diary, and wrote comprehensive prose covering the system from first principles.
+
+### What I did
+- Ran `docmgr ticket create-ticket --ticket FIX-SQLETON-DUCKDB-LINK --title "Fix sqleton compile: duplicate DuckDB static library linker errors" --topics build,go,duckdb,linker`.
+- Added a design document: `docmgr doc add --ticket FIX-SQLETON-DUCKDB-LINK --doc-type design-doc --title "Sqleton DuckDB Linker Conflict: Deep Dive and Fix Guide for New Interns"`.
+- Added a reference diary: `docmgr doc add --ticket FIX-SQLETON-DUCKDB-LINK --doc-type reference --title "Diary"`.
+- Wrote the design doc covering: executive summary, what sqleton is, Go workspaces, DuckDB/Cgo architecture, the exact error, root cause analysis (dependency diamond), step-by-step debugging commands, the fix, prevention strategies, glossary, and references.
+- Wrote the investigation diary covering: reproduction, dependency graph analysis, source inspection, workspace confirmation, fix application, verification, what worked, what didn't, and follow-ups.
+
+### What was tricky to build
+- Docmgr requires strict YAML frontmatter at the very top of markdown files (delimited by `---`). My first drafts had the `# Title` heading before the frontmatter block, which caused `docmgr doc relate` to fail with `frontmatter delimiters '---' not found`. I had to reorder every document to put the frontmatter first.
+
+### What should be done in the future
+- Standardize on a docmgr-aware markdown template so frontmatter always comes first.
+
+---
+
+## Step 4: Relate Files, Validate, and Prepare for ReMarkable Upload
+
+After writing the documents, I needed to relate the key source files to the ticket, validate docmgr quality, and prepare the bundle for reMarkable upload.
+
+### What I did
+- Fixed frontmatter ordering on both the design doc and the investigation diary.
+- Planned to run `docmgr doc relate` for `cmd/sqleton/cmds/db.go`, `go.mod`, `../go.work`, and `../clay/pkg/sql/config.go`.
+- Planned to run `docmgr doctor --ticket FIX-SQLETON-DUCKDB-LINK --stale-after 30`.
+- Planned to upload the bundle via `remarquee upload bundle` with `--remote-dir "/ai/2026/05/02/FIX-SQLETON-DUCKDB-LINK"`.
+
+### What was tricky to build
+- The docmgr frontmatter validation is strict and the error message does not always indicate clearly that the title must come *after* the `---` block. Trial and error was needed.
+
+### What should be done in the future
+- N/A for this step.

--- a/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/tasks.md
+++ b/ttmp/2026/05/02/FIX-SQLETON-DUCKDB-LINK--fix-sqleton-compile-duplicate-duckdb-static-library-linker-errors/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -1,16 +1,18 @@
 topics:
-    - slug: backend
-      description: Backend code and infrastructure
-    - slug: database
-      description: Database integration and connectivity
+    - slug: linker
+      description: Linker, Cgo, static libraries, and native code linking
+    - slug: go
+      description: Go programming language and toolchain
     - slug: duckdb
-      description: DuckDB analytical database engine
+      description: DuckDB database and related drivers
+    - slug: build
+      description: Build system, compilation, and CI topics
 docTypes:
     - slug: index
       description: Ticket index document
 intent:
     - slug: long-term
-      description: Long-term reference document
+      description: Long-term reference and knowledge preservation
 status:
     - slug: active
-      description: Actively being worked on
+      description: Ticket or document is currently active


### PR DESCRIPTION
## Problem


d4e6d2Clay was migrated to the official `duckdb/duckdb-go/v2` driver in PR #119, but sqleton still imported the legacy `marcboeker/go-duckdb` driver directly in `cmd/sqleton/cmds/db.go`.

Because both drivers embed their own C static libraries with identical symbols, linking both into the sqleton binary caused hundreds of `multiple definition` linker errors when running `make build`.

## Solution

Remove the old blank import from `cmd/sqleton/cmds/db.go`. Since `clay/pkg/sql` (which sqleton already imports) already registers the new driver transitively via `_ "github.com/duckdb/duckdb-go/v2"`, no additional code changes are needed.

## Changes

- `cmd/sqleton/cmds/db.go`: removed `_ "github.com/marcboeker/go-duckdb"` import
- `go.mod`: `go mod tidy` moved `marcboeker/go-duckdb` from direct to indirect dependency

## Validation

- `make build` now completes successfully
- `make lint` passes (0 issues)
- `govulncheck` reports 0 vulnerabilities

## Context

This is a follow-up to:
- sqleton PR #252 (`task/sqleton-duckdb-glm`) which originally added the old driver
- clay PR #119 (`task/fix-clay-duckdb`) which migrated clay to the new official driver

Ticket: FIX-SQLETON-DUCKDB-LINK
