### PR TITLE
Add glazed-lint + publish-docs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,4 +20,7 @@ jobs:
           cache: true
       -
         name: Run unit tests
+      - name: Verify Glazed CLI policy
+        run: make glazed-lint
+
         run: go test ./...

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,9 +18,13 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      -
-        name: Run unit tests
+      - name: Verify logcopter package loggers
+        run: make logcopter-check
       - name: Verify Glazed CLI policy
         run: make glazed-lint
-
+      - name: Generate assets
+        run: go generate ./...
+      - name: Verify generated files are up to date
+        run: git diff --exit-code
+      - name: Run unit tests
         run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -97,3 +97,22 @@ logcopter-generate:
 .PHONY: logcopter-check
 logcopter-check:
 	GOWORK=off go tool logcopter-gen -include-main -var zlog -area-prefix go-go-golems.sqleton -strip-prefix github.com/go-go-golems/sqleton -check ./cmd/... ./pkg/...
+
+GLAZED_LINT_BIN ?= /tmp/glazed-lint
+GLAZED_LINT_PKG ?= github.com/go-go-golems/glazed/cmd/tools/glazed-lint
+GLAZED_VERSION ?= v1.2.6
+
+.PHONY: glazed-lint-build glazed-lint
+
+glazed-lint-build:
+	@echo "Building glazed-lint from Glazed module..."
+	@if [ -n "$(GLAZED_VERSION)" ]; then \
+		echo "Installing $(GLAZED_LINT_PKG)@$(GLAZED_VERSION)"; \
+		GOBIN=$(dir $(GLAZED_LINT_BIN)) GOWORK=off go install $(GLAZED_LINT_PKG)@$(GLAZED_VERSION); \
+	else \
+		echo "Installing $(GLAZED_LINT_PKG) from workspace/module"; \
+		GOBIN=$(dir $(GLAZED_LINT_BIN)) go install $(GLAZED_LINT_PKG); \
+	fi
+
+glazed-lint: glazed-lint-build
+	GOWORK=off go vet -vettool=$(GLAZED_LINT_BIN) ./cmd/... ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -114,5 +114,9 @@ glazed-lint-build:
 		GOBIN=$(dir $(GLAZED_LINT_BIN)) go install $(GLAZED_LINT_PKG); \
 	fi
 
+# sqleton has existing raw Cobra flag wiring in its legacy command tree; keep
+# the rollout gate enabled and scope the exception to those command files.
+GLAZED_LINT_ALLOW_PATHS ?= cmd/sqleton/cmds/,cmd/sqleton/main.go
+
 glazed-lint: glazed-lint-build
-	GOWORK=off go vet -vettool=$(GLAZED_LINT_BIN) ./cmd/... ./pkg/...
+	GOWORK=off go vet -vettool=$(GLAZED_LINT_BIN) -glazedclilint.allow-paths=$(GLAZED_LINT_ALLOW_PATHS) ./cmd/... ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ logcopter-check:
 
 GLAZED_LINT_BIN ?= /tmp/glazed-lint
 GLAZED_LINT_PKG ?= github.com/go-go-golems/glazed/cmd/tools/glazed-lint
-GLAZED_VERSION ?= v1.2.6
+GLAZED_VERSION ?= v1.3.6
 
 .PHONY: glazed-lint-build glazed-lint
 


### PR DESCRIPTION
## Summary
- Add glazed-lint Makefile targets (build + run)
- Wire glazed-lint into push.yml CI
- Add publish-docs job to release workflow (disabled by default)

INFRA-004 glazed-lint + docsctl rollout.