### PR TITLE
ci(release): migrate Sqleton to Vault-backed split publishing

### DIFF
--- a/.github/workflows/bootstrap-release-credentials.yml
+++ b/.github/workflows/bootstrap-release-credentials.yml
@@ -1,0 +1,87 @@
+name: bootstrap-release-credentials
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Type MIGRATE_GITHUB_SECRETS_TO_VAULT to copy the existing release secrets into Vault.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Confirm one-time migration
+        shell: bash
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          if [[ "${CONFIRMATION}" != "MIGRATE_GITHUB_SECRETS_TO_VAULT" ]]; then
+            echo "confirmation must be exactly MIGRATE_GITHUB_SECRETS_TO_VAULT" >&2
+            exit 1
+          fi
+
+      - name: Validate legacy secret availability
+        shell: bash
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "${GORELEASER_KEY}"
+          test -n "${FURY_TOKEN}"
+
+      - name: Authenticate to Vault using GitHub OIDC
+        uses: hashicorp/vault-action@v3
+        with:
+          url: https://vault.yolo.scapegoat.dev
+          method: jwt
+          path: github-actions
+          role: release-sqleton-bootstrap
+          jwtGithubAudience: https://vault.yolo.scapegoat.dev
+          exportToken: true
+
+      - name: Write release credentials to Vault without logging values
+        shell: bash
+        env:
+          VAULT_ADDR: https://vault.yolo.scapegoat.dev
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+        run: |
+          set -euo pipefail
+          umask 077
+          goreleaser_payload="${RUNNER_TEMP}/goreleaser-payload.json"
+          fury_payload="${RUNNER_TEMP}/fury-payload.json"
+          trap 'rm -f "${goreleaser_payload}" "${fury_payload}"' EXIT
+
+          jq -n --arg license_key "${GORELEASER_KEY}" \
+            '{data: {license_key: $license_key}}' > "${goreleaser_payload}"
+          jq -n --arg token "${FURY_TOKEN}" \
+            '{data: {token: $token}}' > "${fury_payload}"
+
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "X-Vault-Token: ${VAULT_TOKEN}" \
+            --data @"${goreleaser_payload}" \
+            "${VAULT_ADDR}/v1/kv/data/ci/release/shared/goreleaser-pro" \
+            > /dev/null
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "X-Vault-Token: ${VAULT_TOKEN}" \
+            --data @"${fury_payload}" \
+            "${VAULT_ADDR}/v1/kv/data/ci/release/shared/fury-go-go-golems" \
+            > /dev/null
+
+      - name: Report non-secret completion evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Migrated GoReleaser and Fury credentials to their approved Vault paths."
+          echo "No secret values were printed. Record this workflow run URL in INFRA-007."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,31 @@
+name: release
+
 on:
   push:
-    # run only against tags
     tags:
-      - '*'
+      - "v*"
 
 permissions:
-  contents: write
-  # packages: write
-  # issues: write
-
+  contents: read
 
 jobs:
   release-linux:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install cross-compilers
         run: |
-          sudo apt-get update && sudo apt-get install -y \
+          sudo apt-get update
+          sudo apt-get install -y \
             build-essential \
             gcc-aarch64-linux-gnu \
             gcc-x86-64-linux-gnu
@@ -33,12 +36,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker Login
+      - name: Log in to GHCR with the repository token
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.RELEASE_ACTION_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - run: git fetch --force --tags
       - uses: actions/setup-go@v6
@@ -46,31 +49,42 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+      - name: Read the GoReleaser Pro license
+        uses: hashicorp/vault-action@v3
         with:
-          gpg_private_key: ${{ secrets.GO_GO_GOLEMS_SIGN_KEY }}
-          passphrase: ${{ secrets.GO_GO_GOLEMS_SIGN_PASSPHRASE }}
-          fingerprint: "6EBE1DF0BDF48A1BBA381B5B79983EF218C6ED7E"
+          url: https://vault.yolo.scapegoat.dev
+          method: jwt
+          path: github-actions
+          role: release-sqleton-builder
+          jwtGithubAudience: https://vault.yolo.scapegoat.dev
+          secrets: |
+            kv/data/ci/release/shared/goreleaser-pro license_key | GORELEASER_KEY
 
-      - uses: goreleaser/goreleaser-action@v6
+      - name: Build the Linux split release
+        uses: goreleaser/goreleaser-action@v7
         with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean --skip=publish
+          distribution: goreleaser-pro
+          version: "~> v2"
+          args: release --clean --split
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
-          TAP_GITHUB_TOKEN: ${{ secrets.RELEASE_ACTION_PAT }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GORELEASER_KEY: ${{ env.GORELEASER_KEY }}
+          GGOOS: linux
+
+      - name: Upload Linux split artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: sqleton-dist-linux
+          path: dist
+          if-no-files-found: error
 
   release-darwin:
     runs-on: macos-14
-    needs: release-linux
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -80,22 +94,48 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Import GPG key
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+      - name: Read the GoReleaser Pro license
+        uses: hashicorp/vault-action@v3
         with:
-          gpg_private_key: ${{ secrets.GO_GO_GOLEMS_SIGN_KEY }}
-          passphrase: ${{ secrets.GO_GO_GOLEMS_SIGN_PASSPHRASE }}
-          fingerprint: "6EBE1DF0BDF48A1BBA381B5B79983EF218C6ED7E"
+          url: https://vault.yolo.scapegoat.dev
+          method: jwt
+          path: github-actions
+          role: release-sqleton-builder
+          jwtGithubAudience: https://vault.yolo.scapegoat.dev
+          secrets: |
+            kv/data/ci/release/shared/goreleaser-pro license_key | GORELEASER_KEY
 
-      - uses: goreleaser/goreleaser-action@v6
+      - name: Build the Darwin split release
+        uses: goreleaser/goreleaser-action@v7
         with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
+          distribution: goreleaser-pro
+          version: "~> v2"
+          args: release --clean --split
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
-          TAP_GITHUB_TOKEN: ${{ secrets.RELEASE_ACTION_PAT }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GORELEASER_KEY: ${{ env.GORELEASER_KEY }}
+          GGOOS: darwin
+
+      - name: Upload Darwin split artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: sqleton-dist-darwin
+          path: dist
+          if-no-files-found: error
+
+  publish:
+    needs:
+      - release-linux
+      - release-darwin
+    permissions:
+      contents: write
+      id-token: write
+    uses: go-go-golems/infra-tooling/.github/workflows/publish-goreleaser-release.yml@main
+    with:
+      linux_artifact: sqleton-dist-linux
+      darwin_artifact: sqleton-dist-darwin
+      goreleaser_config: .goreleaser.yaml
+      credential_profile: homebrew-fury
+      vault_role: release-sqleton-publisher
+      homebrew_owner: go-go-golems
+      homebrew_repository: homebrew-go-go-go

--- a/.github/workflows/verify-homebrew-publisher-app.yml
+++ b/.github/workflows/verify-homebrew-publisher-app.yml
@@ -1,0 +1,77 @@
+name: verify-homebrew-publisher-app
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Type VERIFY_HOMEBREW_PUBLISHER_APP to create and delete a temporary tap branch.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Confirm App verification
+        shell: bash
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          if [[ "${CONFIRMATION}" != "VERIFY_HOMEBREW_PUBLISHER_APP" ]]; then
+            echo "confirmation must be exactly VERIFY_HOMEBREW_PUBLISHER_APP" >&2
+            exit 1
+          fi
+
+      - name: Read Homebrew publisher App credential from Vault
+        uses: hashicorp/vault-action@v3
+        with:
+          url: https://vault.yolo.scapegoat.dev
+          method: jwt
+          path: github-actions
+          role: release-sqleton-homebrew-app-verifier
+          jwtGithubAudience: https://vault.yolo.scapegoat.dev
+          secrets: |
+            kv/data/ci/github/homebrew-go-go-go/release-publisher-app app_id | HOMEBREW_APP_ID ;
+            kv/data/ci/github/homebrew-go-go-go/release-publisher-app private_key | HOMEBREW_APP_PRIVATE_KEY
+
+      - name: Mint tap-scoped GitHub App token
+        id: homebrew-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ env.HOMEBREW_APP_ID }}
+          private-key: ${{ env.HOMEBREW_APP_PRIVATE_KEY }}
+          owner: go-go-golems
+          repositories: homebrew-go-go-go
+
+      - name: Create and delete a temporary Homebrew tap branch
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.homebrew-app-token.outputs.token }}
+          TARGET_REPOSITORY: go-go-golems/homebrew-go-go-go
+        run: |
+          set -euo pipefail
+          branch="verify-release-publisher-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          branch_ref="refs/heads/${branch}"
+          created=false
+
+          cleanup() {
+            if [[ "${created}" == true ]]; then
+              gh api --method DELETE "repos/${TARGET_REPOSITORY}/git/${branch_ref}" >/dev/null || \
+                echo "WARNING: failed to delete ${branch_ref}; delete it manually" >&2
+            fi
+          }
+          trap cleanup EXIT
+
+          base_sha="$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          gh api --method POST "repos/${TARGET_REPOSITORY}/git/refs" \
+            -f ref="${branch_ref}" \
+            -f sha="${base_sha}" \
+            >/dev/null
+          created=true
+          echo "created ${branch_ref}; deletion is registered in the cleanup trap"


### PR DESCRIPTION
## Summary

- replace sequential OSS GoReleaser release jobs with Linux and macOS Pro split builds
- use a license-only Vault builder role in platform jobs
- publish through the shared Vault-backed merge workflow
- replace the long-lived GHCR PAT with the repository-scoped GitHub token
- remove unused direct GPG, Cosign, tap, and Fury secret references
- add a manually confirmed one-time GitHub-secret migration workflow
- add a manually confirmed App branch create/delete verifier

## Validation

- Ruby YAML parsing
- `goreleaser check --soft --config .goreleaser.yaml`
- `go test ./...`
- cross-repository `check_sqleton_release_contract.sh`

## Dependencies and follow-up

Merge Terraform #16 before dispatching either manual workflow. An organization owner must create/install the narrow Homebrew publisher App and store its generated private key directly in Vault. After successful migration and verification, remove the temporary workflows and Terraform roles. GoReleaser v2 deprecations remain tracked before a production release.